### PR TITLE
separate result computation from samples, make frequentist coefficients fail more gracefully

### DIFF
--- a/R/uniDimBayesian.R
+++ b/R/uniDimBayesian.R
@@ -159,3 +159,4 @@ reliabilityUniDimBayesian <- function(jaspResults, dataset, options) {
 
   return(out)
 }
+

--- a/R/uniDimBayesian.R
+++ b/R/uniDimBayesian.R
@@ -33,6 +33,9 @@ reliabilityUniDimBayesian <- function(jaspResults, dataset, options) {
   model[["meanItem"]] <- .BayesianMeanItem(jaspResults, dataset, options, model)
   model[["sdItem"]] <- .BayesianSdItem(jaspResults, dataset, options, model)
 
+  model[["scaleResults"]] <- .BayesianComputeScaleResults(jaspResults, options, model)
+  model[["itemResults"]] <- .BayesianComputeItemResults(jaspResults, options, model)
+
   .BayesianScaleTable(jaspResults, model, options)
   .BayesianItemTable(jaspResults, model, options)
   .BayesianProbTable(jaspResults, model, options)
@@ -87,12 +90,6 @@ reliabilityUniDimBayesian <- function(jaspResults, dataset, options) {
   return(jaspResults[["stateContainer"]])
 }
 
-.summarizePosteriorStats <- function(samples, ciValue) {
-  return(list(
-    mean(samples),
-    coda::HPDinterval(coda::mcmc(as.vector(samples)), prob = ciValue)
-  ))
-}
 
 .summarizePosteriorItems <- function(samples, ciValue) {
   return(list(

--- a/R/uniDimBayesianCalcCoeff.R
+++ b/R/uniDimBayesianCalcCoeff.R
@@ -19,8 +19,8 @@
       jaspBase::.setSeedJASP(options)
 
       tmp_out <- try(Bayesrel:::omegaSampler(dataset, options[["noSamples"]], options[["noBurnin"]],
-                                               options[["noThin"]], options[["noChains"]],
-                                               model[["pairwise"]], progressbarTick), silent = TRUE)
+                                             options[["noThin"]], options[["noChains"]],
+                                             model[["pairwise"]], progressbarTick), silent = TRUE)
       if (model[["pairwise"]] && inherits(tmp_out, "try-error")) {
         .quitAnalysis(gettext("Sampling the posterior factor model for omega failed. Try changing to 'Exclude cases listwise' in 'Advanced Options'"))
       }
@@ -29,14 +29,11 @@
       out[["residuals"]] <- apply(tmp_out$psi, 3, as.vector)
     }
 
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
-
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["omegaScaleObj"]] <- createJaspState(out,
-                                                         dependencies = c("omegaScale", "credibleIntervalValueScale"))
+    stateContainer[["omegaScaleObj"]] <- createJaspState(out, dependencies = "omegaScale")
   }
 
   return(out)
@@ -68,8 +65,8 @@
       jaspBase::.setSeedJASP(options)
 
       out[["itemSamp"]] <- array(0, c(options[["noChains"]],
-                        length(seq(1, options[["noSamples"]] - options[["noBurnin"]], options[["noThin"]])),
-                        ncol(dataset)))
+                                      length(seq(1, options[["noSamples"]] - options[["noBurnin"]], options[["noThin"]])),
+                                      ncol(dataset)))
 
       for (i in seq_len(ncol(dataset))) {
         out[["itemSamp"]][, , i] <- Bayesrel:::omegaSampler(dataset[, -i],
@@ -80,13 +77,12 @@
       out[["itemSamp"]] <- matrix(out[["itemSamp"]], dd[1] * dd[2], ncol(dataset))
 
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["omegaItemObj"]] <- createJaspState(out, dependencies = c("omegaItem", "credibleIntervalValueItem"))
+    stateContainer[["omegaItemObj"]] <- createJaspState(out, dependencies = "omegaItem")
   }
 
   return(out)
@@ -110,14 +106,12 @@
       startProgressbar(model[["progressbarLength"]])
       out[["samp"]] <- coda::mcmc(apply(model[["gibbsSamp"]], MARGIN = c(1, 2), Bayesrel:::applyalpha, progressbarTick))
     }
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["alphaScaleObj"]] <- createJaspState(out,
-                                                          dependencies = c("alphaScale", "credibleIntervalValueScale"))
+    stateContainer[["alphaScaleObj"]] <- createJaspState(out, dependencies = "alphaScale")
   }
 
   return(out)
@@ -147,14 +141,12 @@
       out[["itemSamp"]] <- .BayesItemDroppedStats(model[["gibbsSamp"]], Bayesrel:::applyalpha, progressbarTick)
 
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["alphaItemObj"]] <- createJaspState(out,
-                                                         dependencies = c("alphaItem", "credibleIntervalValueItem"))
+    stateContainer[["alphaItemObj"]] <- createJaspState(out, dependencies = "alphaItem")
   }
 
   return(out)
@@ -179,15 +171,12 @@
       out[["samp"]] <- coda::mcmc(apply(model[["gibbsSamp"]], MARGIN = c(1, 2), Bayesrel:::applylambda2, progressbarTick))
 
     }
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["lambda2ScaleObj"]] <- createJaspState(out,
-                                                           dependencies = c("lambda2Scale",
-                                                                            "credibleIntervalValueScale"))
+    stateContainer[["lambda2ScaleObj"]] <- createJaspState(out, dependencies = "lambda2Scale")
   }
 
   return(out)
@@ -216,14 +205,12 @@
       out[["itemSamp"]] <- .BayesItemDroppedStats(model[["gibbsSamp"]], Bayesrel:::applylambda2, progressbarTick)
 
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["lambda2ItemObj"]] <- createJaspState(out,
-                                                           dependencies = c("lambda2Item", "credibleIntervalValueItem"))
+    stateContainer[["lambda2ItemObj"]] <- createJaspState(out, dependencies = "lambda2Item")
   }
 
   return(out)
@@ -246,14 +233,12 @@
       startProgressbar(model[["progressbarLength"]])
       out[["samp"]] <- coda::mcmc(apply(model[["gibbsSamp"]], MARGIN = c(1, 2), Bayesrel:::applylambda6, progressbarTick))
     }
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["lambda6ScaleObj"]] <- createJaspState(out,
-                                                            dependencies = c("lambda6Scale","credibleIntervalValueScale"))
+    stateContainer[["lambda6ScaleObj"]] <- createJaspState(out, dependencies = "lambda6Scale")
   }
 
   return(out)
@@ -283,14 +268,12 @@
       out[["itemSamp"]] <- .BayesItemDroppedStats(model[["gibbsSamp"]], Bayesrel:::applylambda6, progressbarTick)
 
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["lambda6ItemObj"]] <- createJaspState(out,
-                                                           dependencies = c("lambda6Item", "credibleIntervalValueItem"))
+    stateContainer[["lambda6ItemObj"]] <- createJaspState(out, dependencies = "lambda6Item")
   }
 
   return(out)
@@ -322,14 +305,11 @@
 
     }
 
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
-
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["glbScaleObj"]] <- createJaspState(out,
-                                                   dependencies = c("glbScale", "credibleIntervalValueScale"))
+    stateContainer[["glbScaleObj"]] <- createJaspState(out, dependencies = "glbScale")
   }
 
   return(out)
@@ -365,14 +345,12 @@
       }
 
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["glbItemObj"]] <- createJaspState(out,
-                                                       dependencies = c("glbItem", "credibleIntervalValueItem"))
+    stateContainer[["glbItemObj"]] <- createJaspState(out, dependencies = "glbItem")
   }
 
   return(out)
@@ -406,14 +384,12 @@
       out[["samp"]] <- coda::mcmc(out[["samp"]])
 
     }
-    out[c("est", "cred")] <- .summarizePosteriorStats(out[["samp"]], ciValue)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["avgCorObj"]] <- createJaspState(out,
-                                                      dependencies = c("averageItemItemCor", "credibleIntervalValueScale"))
+    stateContainer[["avgCorObj"]] <- createJaspState(out, dependencies = "averageItemItemCor")
   }
 
   return(out)
@@ -486,17 +462,15 @@
 
       jaspBase::.setSeedJASP(options)
       out[["itemSamp"]] <- .itemRestCor(dataset, options[["noSamples"]], options[["noBurnin"]],
-                              options[["noThin"]], options[["noChains"]], model[["pairwise"]],
-                              callback = progressbarTick)
+                                        options[["noThin"]], options[["noChains"]], model[["pairwise"]],
+                                        callback = progressbarTick)
     }
-    out[c("itemEst", "itemCred")] <- .summarizePosteriorItems(out[["itemSamp"]], ciValueItem)
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerB(jaspResults)
-    stateContainer[["itemRestObj"]] <- createJaspState(out,
-                                                       dependencies = c("itemRestCor", "credibleIntervalValueItem"))
+    stateContainer[["itemRestObj"]] <- createJaspState(out, dependencies = "itemRestCor")
   }
 
   return(out)
@@ -554,7 +528,7 @@
   for (i in seq(ncol(dataset))) {
     help_dat <- cbind(as.matrix(dataset[, i]), rowMeans(as.matrix(dataset[, -i]), na.rm = TRUE))
     ircor_samp[, i] <- .WishartCorTransform(help_dat, n.iter = n.iter, n.burnin = n.burnin, thin = thin,
-                                              n.chains = n.chains, pairwise = pairwise, callback = callback)
+                                            n.chains = n.chains, pairwise = pairwise, callback = callback)
   }
 
   return(ircor_samp)
@@ -567,5 +541,109 @@
   tmp_cor <- apply(tmp_cov, c(1), cov2cor)
   out <- tmp_cor[2, ]
   callback()
+  return(out)
+}
+
+
+.BayesianComputeScaleResults <- function(jaspResults, options, model) {
+  if (!is.null(.getStateContainerB(jaspResults)[["scaleResultsObj"]]$object))
+    return(.getStateContainerB(jaspResults)[["scaleResultsObj"]]$object)
+
+  out <- model[["scaleResults"]]
+  if (is.null(out))
+    out <- list()
+
+  if (is.null(model[["empty"]])) {
+
+    ciValue <- options[["credibleIntervalValueScale"]]
+
+    selected <- names(which(model[["derivedOptions"]][["selectedEstimators"]]))
+    # first the coefficients with samples
+    samps <- model[selected]
+    samps <- lapply(samps, function(x) x[["samp"]])
+    samps[sapply(samps, is.null)] <- NULL
+
+    out[["est"]] <- lapply(samps, mean)
+    out[["cred"]] <- lapply(samps, function(x) coda::HPDinterval(coda::mcmc(c(x)), prob = ciValue))
+
+    if (options[["rHat"]]) {
+      tmp <- lapply(samps, function(x) {lapply(as.data.frame(t(x)), coda::mcmc)})
+      out[["rHat"]] <- lapply(tmp, function(x) {coda::gelman.diag(coda::as.mcmc.list(x))[["psrf"]][, 1]})
+    }
+
+    # check for mean and sd
+    if ("meanScale" %in% selected) {
+      out[["est"]][["meanScale"]] <- model[["meanScale"]][["est"]]
+      out[["cred"]][["meanScale"]] <- model[["meanScale"]][["cred"]]
+      if (options[["rHat"]]) {
+        out[["rHat"]][["meanScale"]] <- NA_real_
+      }
+    }
+    if ("sdScale" %in% selected) {
+      out[["est"]][["sdScale"]] <- model[["sdScale"]][["est"]]
+      out[["cred"]][["sdScale"]] <- model[["sdScale"]][["cred"]]
+      if (options[["rHat"]]) {
+        out[["rHat"]][["sdScale"]] <- NA_real_
+      }
+    }
+
+    stateContainer <- .getStateContainerB(jaspResults)
+    stateContainer[["scaleResultsObj"]] <- createJaspState(out, dependencies = c("credibleIntervalValueScale",
+                                                                                 "meanScale", "sdScale", "rHat",
+                                                                                 "alphaScale", "omegaScale",
+                                                                                 "lambda2Scale", "lambda6Scale",
+                                                                                 "glbScale","averageInterItemCor",
+                                                                                 "meanMethod", "sdMethod"))
+
+  }
+
+  return(out)
+
+}
+
+
+.BayesianComputeItemResults <- function(jaspResults, options, model) {
+  if (!is.null(.getStateContainerB(jaspResults)[["itemResultsObj"]]$object))
+    return(.getStateContainerB(jaspResults)[["itemResultsObj"]]$object)
+
+  out <- model[["itemResults"]]
+  if (is.null(out))
+    out <- list()
+
+  chosen <- any(model[["derivedOptions"]][["itemDroppedSelected"]])
+
+  if (is.null(model[["empty"]]) && chosen) {
+
+    ciValue <- options[["credibleIntervalValueItem"]]
+
+    selected <- names(which(model[["derivedOptions"]][["itemDroppedSelected"]]))
+    # first the coefficients with samples
+    samps <- model[selected]
+    samps <- lapply(samps, function(x) x[["itemSamp"]])
+    samps[sapply(samps, is.null)] <- NULL
+
+    out[["est"]] <- lapply(samps, colMeans)
+    out[["cred"]] <- lapply(samps, function(x) coda::HPDinterval(coda::mcmc(x), prob = ciValue))
+
+    # check for mean and sd
+    if ("meanItem" %in% selected) {
+      out[["est"]][["meanItem"]] <- model[["meanItem"]][["itemEst"]]
+      out[["cred"]][["meanItem"]] <- model[["meanItem"]][["itemCred"]]
+
+    }
+    if ("sdItem" %in% selected) {
+      out[["est"]][["sdItem"]] <- model[["sdItem"]][["itemEst"]]
+      out[["cred"]][["sdItem"]] <- model[["sdItem"]][["itemCred"]]
+
+    }
+
+    stateContainer <- .getStateContainerB(jaspResults)
+    stateContainer[["itemResultsObj"]] <- createJaspState(out, dependencies = c("omegaItem",  "alphaItem",
+                                                                                "lambda2Item",  "lambda6Item",
+                                                                                "glbItem","credibleIntervalValueItem",
+                                                                                "itemRestCor", "meanItem", "sdItem"))
+
+  }
+
   return(out)
 }

--- a/R/uniDimBayesianOutputPlots.R
+++ b/R/uniDimBayesianOutputPlots.R
@@ -187,7 +187,6 @@
     ordering <- NULL
   }
 
-
   if (is.null(model[["empty"]]) && options[["plotItem"]]) {
     for (j in seq_along(idxSelected)) {
       i <- idxSelected[j]
@@ -202,9 +201,11 @@
           # use the coefficient item object in the model list, and the object directly before it,
           # which is always the corresponding scale object
           prevNumber <- which(names(model) == nm) - 1
+          name <- unlist(strsplit(nm, "Item"))
+          coefPos <- grep(name, names(model[["scaleResults"]][["est"]]))
           p <- .makeIfItemPlot(model[[nm]], model[[prevNumber]],
                                model[["itemResults"]][["est"]][[nm]],
-                               model[["scaleResults"]][["est"]][[nm]],
+                               model[["scaleResults"]][["est"]][[coefPos]],
                                nmsLabs[[i]],
                                options[["credibleIntervalValueItem"]],
                                ordering = ordering, model[["itemsDropped"]])
@@ -257,7 +258,7 @@
     est$name <- c(names, "original")
 
     if (ordering == "orderItemMean") {
-      dists <- abs(coefScaleEst - coefItem[["itemEst"]])
+      dists <- abs(coefScaleEst - coefItemEst)
       dists[length(dists) + 1] <- 0
       est <- est[order(dists, decreasing = FALSE), ]
       dat$var <- factor(dat$var, levels = c(est$name))

--- a/R/uniDimBayesianOutputPlots.R
+++ b/R/uniDimBayesianOutputPlots.R
@@ -53,9 +53,9 @@
         } else {
           prior <- priors[[nm]]
         }
-        p <- .makeSinglePosteriorPlot(model[[nm]], nmsLabs[[i]],
-                                                         options[["fixXRange"]], shadePlots,
-                                                         options[["dispPrior"]], prior)
+        p <- .makeSinglePosteriorPlot(model[[nm]], model[["scaleResults"]][["cred"]][[nm]], nmsLabs[[i]],
+                                      options[["fixXRange"]], shadePlots,
+                                      options[["dispPrior"]], prior)
         plotObj <- createJaspPlot(plot = p, title = nmsObjs[i])
         plotObj$dependOn(options = names(idxSelected[i]))
         plotObj$position <- i
@@ -71,7 +71,7 @@
   return()
 }
 
-.makeSinglePosteriorPlot <- function(coefList, nms, fixXRange, shade = NULL, priorTrue, priorSample) {
+.makeSinglePosteriorPlot <- function(coefList, coefResults, nms, fixXRange, shade = NULL, priorTrue, priorSample) {
 
   # TODO: consider precomputing all densities (maybe with kernsmooth?) and reducing memory that way
 
@@ -91,7 +91,7 @@
   ymax <- max(d$y) / .9
   yBreaks <- jaspGraphs::getPrettyAxisBreaks(c(0, ymax))
   ymax <- max(yBreaks)
-  scaleCriRound <- round(coefList[["cred"]], 3)
+  scaleCriRound <- round(coefResults, 3)
   datCri <- data.frame(xmin = scaleCriRound[1L], xmax = scaleCriRound[2L], y = .925 * ymax)
   height <- (ymax - .925 * ymax) / 2
   if (fixXRange) {
@@ -202,7 +202,10 @@
           # use the coefficient item object in the model list, and the object directly before it,
           # which is always the corresponding scale object
           prevNumber <- which(names(model) == nm) - 1
-          p <- .makeIfItemPlot(model[[nm]], model[[prevNumber]], nmsLabs[[i]],
+          p <- .makeIfItemPlot(model[[nm]], model[[prevNumber]],
+                               model[["itemResults"]][["est"]][[nm]],
+                               model[["scaleResults"]][["est"]][[nm]],
+                               nmsLabs[[i]],
                                options[["credibleIntervalValueItem"]],
                                ordering = ordering, model[["itemsDropped"]])
           plotObjItem <- createJaspPlot(plot = p, title = nmsObjs[i], width = 400)
@@ -224,7 +227,7 @@
   return()
 }
 
-.makeIfItemPlot <- function(coefItem, coefScale, nms, int, ordering, variables) {
+.makeIfItemPlot <- function(coefItem, coefScale, coefItemEst, coefScaleEst, nms, int, ordering, variables) {
   n_row <- length(variables)
   lower <- (1 - int) / 2
   upper <- int + (1 - int) / 2
@@ -248,13 +251,13 @@
   dat$var <- factor(dat$var, levels = unique(dat$var))
 
   if (!is.null(ordering)) {
-    est <- as.data.frame(coefItem[["itemEst"]])
+    est <- as.data.frame(coefItemEst)
     est[n_row + 1, ] <- 1
     colnames(est) <- "value"
     est$name <- c(names, "original")
 
     if (ordering == "orderItemMean") {
-      dists <- abs(coefScale[["est"]] - coefItem[["itemEst"]])
+      dists <- abs(coefScaleEst - coefItem[["itemEst"]])
       dists[length(dists) + 1] <- 0
       est <- est[order(dists, decreasing = FALSE), ]
       dat$var <- factor(dat$var, levels = c(est$name))
@@ -345,7 +348,7 @@
     stateContainer[["omegaPPC"]] <- plot
   }
 
-return()
+  return()
 }
 
 

--- a/R/uniDimBayesianOutputTables.R
+++ b/R/uniDimBayesianOutputTables.R
@@ -131,16 +131,20 @@
     }
   }
 
+
   if (is.null(model[["empty"]])) {
-
     tb <- data.frame(variable = model[["itemsDropped"]])
-
     for (j in seq_along(idxSelected)) {
       i <- idxSelected[j]
       nm <- names(idxSelected[j])
 
-      if (i %in% c(1:6)) { # check this when more estimators are included !!!!!!!!!!!!!!!!!!!!!
-        newtb <- cbind(postMean = model[["itemResults"]][["est"]][[nm]], model[["itemResults"]][["cred"]][[nm]])
+      if (i %in% 1:6) {
+        rows <- length(options[["variables"]])
+        if (rows < 3 && nm != "itemRestCor") {
+          newtb <- cbind(postMean = rep(NaN, rows), matrix(NaN, rows, 2, dimnames = list(NULL, c("lower", "upper"))))
+        } else {
+          newtb <- cbind(postMean = model[["itemResults"]][["est"]][[nm]], model[["itemResults"]][["cred"]][[nm]])
+        }
       } else {
         newtb <- cbind(postMean = model[["itemResults"]][["est"]][[nm]])
       }

--- a/R/uniDimBayesianOutputTables.R
+++ b/R/uniDimBayesianOutputTables.R
@@ -48,17 +48,11 @@
     i <- idxSelected[j]
     nm <- names(idxSelected[j])
 
-    newData <- data.frame(est = c(unlist(model[[nm]][["est"]], use.names = FALSE),
-                                  unlist(model[[nm]][["cred"]], use.names = FALSE)))
+    newData <- data.frame(est = c(unlist(model[["scaleResults"]][["est"]][[nm]], use.names = FALSE),
+                                  unlist(model[["scaleResults"]][["cred"]][[nm]], use.names = FALSE)))
 
     if (options[["rHat"]]) {
-      if (opts[i] == "mean" || opts[i] == "sd") {
-        rhat <- NA_real_
-      } else {
-        tmp <- lapply(as.data.frame(t(model[[nm]][["samp"]])), coda::mcmc)
-        rhat <- coda::gelman.diag(coda::as.mcmc.list(tmp))[["psrf"]][, 1]
-      }
-      newData <- rbind(newData, rhat)
+      newData <- rbind(newData, model[["scaleResults"]][["rHat"]][[nm]])
     }
     colnames(newData) <- paste0(colnames(newData), i)
     allData <- cbind(allData, newData)
@@ -146,9 +140,9 @@
       nm <- names(idxSelected[j])
 
       if (i %in% c(1:6)) { # check this when more estimators are included !!!!!!!!!!!!!!!!!!!!!
-        newtb <- cbind(postMean = model[[nm]][["itemEst"]], model[[nm]][["itemCred"]])
+        newtb <- cbind(postMean = model[["itemResults"]][["est"]][[nm]], model[["itemResults"]][["cred"]][[nm]])
       } else {
-        newtb <- cbind(postMean = model[[nm]][["itemEst"]])
+        newtb <- cbind(postMean = model[["itemResults"]][["est"]][[nm]])
       }
       colnames(newtb) <- paste0(colnames(newtb), i)
       tb <- cbind(tb, newtb)
@@ -221,7 +215,7 @@
     probsPrior <- numeric(sum(selected))
 
     for (i in seq_len(length(idxSelected))) {
-        nm <- names(idxSelected[i])
+      nm <- names(idxSelected[i])
       samp_tmp <- as.vector(model[[nm]][["samp"]])
       probsPost[i] <- mean(samp_tmp > low) -
         mean(samp_tmp > high)

--- a/R/uniDimBayesianPreCalc.R
+++ b/R/uniDimBayesianPreCalc.R
@@ -76,13 +76,13 @@
   if (is.null(model[["gibbsSamp"]]) &&
       (options[["alphaScale"]] || options[["lambda2Scale"]] || options[["lambda6Scale"]] || options[["glbScale"]] ||
        options[["averageInterItemCor"]])
-      ) {
+  ) {
 
     startProgressbar(options[["noSamples"]] * options[["noChains"]])
     dataset <- scale(dataset, scale = FALSE)
     c_out <- try(Bayesrel:::covSamp(dataset, options[["noSamples"]], options[["noBurnin"]],
-                                  options[["noThin"]], options[["noChains"]],
-                                  model[["pairwise"]], progressbarTick), silent = TRUE)
+                                    options[["noThin"]], options[["noChains"]],
+                                    model[["pairwise"]], progressbarTick), silent = TRUE)
     if (model[["pairwise"]] && inherits(c_out, "try-error")) {
       .quitAnalysis(gettext("Sampling the posterior covariance matrix for either one of [alpha, lambda2, lambda6, glb] failed. Try changing to 'Exclude cases listwise' in 'Advanced Options'"))
     }

--- a/R/uniDimCommon.R
+++ b/R/uniDimCommon.R
@@ -157,3 +157,10 @@
 .is.empty <- function(model) {
   !is.null(model[["empty"]])
 }
+
+
+.sampleListHelper <- function(ll, llName) {
+  samps <- lapply(ll, `[[`, llName)
+  samps[lengths(samps) == 0] <- NULL
+  return(samps)
+}

--- a/R/uniDimCommon.R
+++ b/R/uniDimCommon.R
@@ -7,7 +7,7 @@
     dataset <- .readDataSetToEnd(
       columns.as.numeric  = variables,
       exclude.na.listwise = if (options[["missingValues"]] == "excludeCasesListwise") variables else NULL
-      )
+    )
   }
   return(dataset)
 }

--- a/R/uniDimFrequentist.R
+++ b/R/uniDimFrequentist.R
@@ -32,6 +32,8 @@ reliabilityUniDimFrequentist <- function(jaspResults, dataset, options) {
   model[["meanItem"]] <- .frequentistMeanItem(jaspResults, dataset, options, model)
   model[["sdItem"]] <- .frequentistSdItem(jaspResults, dataset, options, model)
 
+  model[["scaleResults"]] <- .frequentistComputeScaleResults(jaspResults, dataset, options, model)
+
   .frequentistScaleTable(jaspResults, model, options)
   .frequentistItemTable(jaspResults, model, options)
   .frequentistSingleFactorFitTable(jaspResults, model, options)
@@ -45,17 +47,16 @@ reliabilityUniDimFrequentist <- function(jaspResults, dataset, options) {
 
   derivedOptions <- list(
     selectedEstimators  = unlist(options[c("omegaScale", "alphaScale", "lambda2Scale", "lambda6Scale",
-                                            "glbScale", "averageInterItemCor", "meanScale", "sdScale")]),
+                                           "glbScale", "averageInterItemCor", "meanScale", "sdScale")]),
     itemDroppedSelected = unlist(options[c("omegaItem", "alphaItem", "lambda2Item", "lambda6Item",
-                                            "glbItem", "itemRestCor", "meanItem", "sdItem")]),
+                                           "glbItem", "itemRestCor", "meanItem", "sdItem")]),
     namesEstimators     = list(
       tables = c("McDonald's \u03C9", "Cronbach's \u03B1", "Guttman's \u03BB2", "Guttman's \u03BB6",
                  "Greatest Lower Bound", "Average interitem correlation", "mean", "sd"),
       tables_item = c("McDonald's \u03C9", "Cronbach's \u03B1", "Guttman's \u03BB2", "Guttman's \u03BB6",
                       gettext("Greatest Lower Bound"), gettext("Item-rest correlation"), gettext("mean"), gettext("sd")),
       coefficients = c("McDonald's \u03C9", "Cronbach's \u03B1", "Guttman's \u03BB2", "Guttman's \u03BB6",
-                       gettext("Greatest Lower Bound"))
-    )
+                       gettext("Greatest Lower Bound")))
   )
   return(derivedOptions)
 }
@@ -66,8 +67,8 @@ reliabilityUniDimFrequentist <- function(jaspResults, dataset, options) {
     return(jaspResults[["stateContainer"]])
 
   jaspResults[["stateContainer"]] <- createJaspContainer(dependencies = c("variables", "reverseScaledItems", "noSamples",
-                                                                         "missingValues", "bootType", "setSeed",
-                                                                         "seed", "intervalOn", "disableSampleSave")
+                                                                          "missingValues", "bootType", "setSeed",
+                                                                          "seed", "intervalOn", "disableSampleSave")
   )
 
   return(jaspResults[["stateContainer"]])

--- a/R/uniDimFrequentistCalcCoeff.R
+++ b/R/uniDimFrequentistCalcCoeff.R
@@ -642,8 +642,8 @@
       bootCoeffs <- c("lambda2Scale", "glbScale", "averageInterItemCor")
       selected <- bootCoeffs[bootCoeffs %in% names(which(model[["derivedOptions"]][["selectedEstimators"]]))]
 
-      samps <- model[selected]
-      samps <- lapply(samps, function(x) x[["samp"]])
+      sampellist <- model[selected]
+      samps <- .sampleListHelper(sampellist, "samp")
       out[["conf"]][selected] <- lapply(samps, function(x) {quantile(x, probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2),
                                                                      na.rm = TRUE)})
     }

--- a/R/uniDimFrequentistCalcCoeff.R
+++ b/R/uniDimFrequentistCalcCoeff.R
@@ -7,61 +7,26 @@
   if (is.null(out))
     out <- list()
 
-  if (options[["omegaScale"]] && is.null(model[["empty"]])) {
+  if (options[["omegaScale"]] && is.null(model[["empty"]]) && options[["intervalOn"]]) {
 
     ciValue <- options[["confidenceIntervalValue"]]
-
     if (options[["omegaMethod"]] == "cfa") {
-
-      dataset <- scale(dataset, scale = FALSE)
-      omegaO <- Bayesrel:::omegaFreqData(dataset, interval = ciValue, omega.int.analytic = TRUE,
-                                         pairwise = model[["pairwise"]])
-      if (is.na(omegaO[["omega"]])) {
-        out[["error"]] <- gettext("Omega calculation with CFA failed. Try changing to PFA in Advanced Options")
-      } else {
-        out[["omegaFit"]] <- omegaO[["indices"]]
-        out[["est"]] <- omegaO[["omega"]]
-
-        if (options[["intervalOn"]]) {
-
-          if (options[["omegaInterval"]] == "omegaAnalytic") {
-            out[["conf"]] <- c(omegaO$omega_lower, omegaO$omega_upper)
-          } else {
-
-            parametric <- options[["bootType"]] == "parametric"
-
-            omegaboot <- out[["omegaBoot"]]
-            if (is.null(omegaboot)) {
-              jaspBase::.setSeedJASP(options)
-              omegaboot <- Bayesrel:::omegaFreqData(dataset, interval = ciValue, omega.int.analytic = FALSE,
-                                                    pairwise = model[["pairwise"]], parametric = parametric,
-                                                    n.boot = options[["noSamples"]])
-            }
-            if (is.na(omegaboot[["omega_lower"]]) || is.na(omegaboot[["omega_upper"]])) {
-              out[["error"]] <- gettext("Omega bootstrapped interval calculation with CFA failed.
-                                          \n Try changing to PFA in 'Advanced Options'")
-            } else {
-              out[["conf"]] <- c(omegaboot[["omega_lower"]], omegaboot[["omega_upper"]])
-            }
-          }
+      if (options[["omegaInterval"]] == "omegaBoot") {
+        parametric <- options[["bootType"]] == "parametric"
+        omegaboot <- out[["samp"]]
+        if (is.null(omegaboot)) {
+          startProgressbar(options[["noSamples"]])
+          jaspBase::.setSeedJASP(options)
+          omegaboot <- Bayesrel:::omegaFreqData(dataset, interval = ciValue, omega.int.analytic = FALSE,
+                                                pairwise = model[["pairwise"]], parametric = parametric,
+                                                n.boot = options[["noSamples"]], callback = progressbarTick)
+          out[["samp"]] <- omegaboot[["omega_boot"]]
         }
       }
-
     } else { # omega with pfa
-      out[["est"]] <- Bayesrel:::applyomegaPFA(model[["data_cov"]])
-      if (is.na(out[["est"]])) {
-        out[["error"]] <- gettext("Omega calculation with PFA failed")
-      } else {
-        if (options[["intervalOn"]]) {
-          if (is.null(out[["samp"]])) {
-            startProgressbar(options[["noSamples"]])
-            out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applyomegaPFA, callback = progressbarTick)
-          }
-          if (sum(!is.na(out[["samp"]])) < 3)
-            out[["error"]] <- gettext("Omega interval calculation with pfa failed")
-          else
-            out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
-        }
+      if (is.null(out[["samp"]])) {
+        startProgressbar(options[["noSamples"]])
+        out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applyomegaPFA, callback = progressbarTick)
       }
     }
 
@@ -69,9 +34,8 @@
       return(out)
 
     stateContainer <- .getStateContainerF(jaspResults)
-    stateContainer[["omegaScaleObj"]] <- createJaspState(out,
-                                                          dependencies = c("omegaScale", "omegaMethod",
-                                                                           "omegaInterval", "confidenceIntervalValue"))
+    stateContainer[["omegaScaleObj"]] <- createJaspState(out, dependencies = c("omegaScale", "omegaMethod",
+                                                                               "omegaInterval"))
   }
 
   return(out)
@@ -96,25 +60,27 @@
 
       dataset <- scale(dataset, scale = FALSE)
       # do we have to compute item dropped values
-        if (is.null(out[["itemDropped"]])) {
-          out[["itemDropped"]] <- numeric(ncol(dataset))
-          for (i in seq_len(ncol(dataset))) {
-            out[["itemDropped"]][i] <- Bayesrel:::applyomegaCFAData(dataset[, -i], interval = .95,
-                                                                      pairwise = model[["pairwise"]])
-          }
+      if (is.null(out[["itemDropped"]])) {
+        out[["itemDropped"]] <- numeric(ncol(dataset))
+        for (i in seq_len(ncol(dataset))) {
+          out[["itemDropped"]][i] <- Bayesrel:::applyomegaCFAData(dataset[, -i], interval = .95,
+                                                                  pairwise = model[["pairwise"]])
         }
-        if (anyNA(out[["itemDropped"]]))
-          out[["error"]] <- gettext("Omega item dropped statistics with CFA failed")
-
-      } else { # omega with pfa
-      # do we have to compute item dropped values
-        if (is.null(out[["itemDropped"]]))
-          out[["itemDropped"]] <- .freqItemDroppedStats(model[["data_cov"]], Bayesrel:::applyomegaPFA)
-
-        if (anyNA(out[["itemDropped"]]))
-          out[["error"]] <- gettext("Omega item dropped statistics with PFA failed")
-
       }
+      if (anyNA(out[["itemDropped"]])) {
+        out[["error"]] <- gettext("Omega item dropped statistics with CFA failed.")
+        out[["itemDropped"]] <- rep(NaN, ncol(dataset))
+      }
+
+    } else { # omega with pfa
+      # do we have to compute item dropped values
+      if (is.null(out[["itemDropped"]]))
+        out[["itemDropped"]] <- .freqItemDroppedStats(model[["data_cov"]], Bayesrel:::applyomegaPFA)
+
+      if (anyNA(out[["itemDropped"]]))
+        out[["error"]] <- gettext("Omega item dropped statistics with PFA failed.")
+
+    }
 
     if (options[["disableSampleSave"]])
       return(out)
@@ -139,48 +105,27 @@
 
     # alpha unstandardized
     if (options[["alphaMethod"]] == "alphaUnstand") {
-
-      out[["est"]] <- Bayesrel:::applyalpha(model[["data_cov"]])
-
       # do we need an interval estimate?
       if (options[["intervalOn"]]) {
-        ciValue <- options[["confidenceIntervalValue"]]
-
-        # should the interval be analytic
-        if (options[["alphaInterval"]] == "alphaAnalytic") {
-          out[["conf"]] <- Bayesrel:::ciAlpha(1 - ciValue, model[["n"]], model[["data_cov"]])
-
-        } else {
+        # should the interval be bootstrapped
+        if (options[["alphaInterval"]] == "alphaBoot") {
           if (is.null(out[["samp"]])) {
             startProgressbar(options[["noSamples"]])
             out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applyalpha, callback = progressbarTick)
           }
-          out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2))
         }
       }
-
     } else { # alpha standardized
-      ccor <- model[["data_cor"]]
-      out[["est"]] <- Bayesrel:::applyalpha(ccor)
-
       # do we need an interval estimate?
       if (options[["intervalOn"]]) {
-        ciValue <- options[["confidenceIntervalValue"]]
-
-        # should the interval be analytic
-        if (options[["alphaInterval"]] == "alphaAnalytic") {
-          out[["conf"]] <- Bayesrel:::ciAlpha(1 - ciValue, model[["n"]], ccor)
-
-        } else {
-
+        # should the interval be bootstrapped
+        if (options[["alphaInterval"]] == "alphaBoot") {
           if (is.null(out[["sampCor"]])) {
             out[["sampCor"]] <- numeric(options[["noSamples"]])
             for (i in seq_len(options[["noSamples"]])) {
               out[["sampCor"]][i] <- Bayesrel:::applyalpha(cov2cor(model[["bootSamp"]][i, , ]))
             }
           }
-          out[["conf"]] <- quantile(out[["sampCor"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
-
         }
       }
     }
@@ -189,9 +134,8 @@
       return(out)
 
     stateContainer <- .getStateContainerF(jaspResults)
-    stateContainer[["alphaScaleObj"]] <- createJaspState(out,
-                                                         dependencies = c("alphaScale", "alphaMethod",
-                                                                          "alphaInterval", "confidenceIntervalValue"))
+    stateContainer[["alphaScaleObj"]] <- createJaspState(out, dependencies = c("alphaScale", "alphaMethod",
+                                                                               "alphaInterval"))
   }
   return(out)
 }
@@ -235,35 +179,26 @@
 .frequentistLambda2Scale <- function(jaspResults, dataset, options, model) {
 
   if (!is.null(.getStateContainerF(jaspResults)[["lambda2ScaleObj"]]$object))
-      return(.getStateContainerF(jaspResults)[["lambda2ScaleObj"]]$object)
+    return(.getStateContainerF(jaspResults)[["lambda2ScaleObj"]]$object)
 
   out <- model[["lambda2Scale"]]
   if (is.null(out))
     out <- list()
   # is coefficient even checked?
   if (options[["lambda2Scale"]]  && is.null(model[["empty"]])) {
-
-    out[["est"]] <- Bayesrel:::applylambda2(model[["data_cov"]])
-
     # do we need an interval estimate?
     if (options[["intervalOn"]]) {
-
-      ciValue <- options[["confidenceIntervalValue"]]
-
       if (is.null(out[["samp"]])) {
         startProgressbar(options[["noSamples"]])
         out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applylambda2, callback = progressbarTick)
       }
-      out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
-
     }
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerF(jaspResults)
-    stateContainer[["lambda2ScaleObj"]] <- createJaspState(out,
-                                                           dependencies = c("lambda2Scale", "confidenceIntervalValue"))
+    stateContainer[["lambda2ScaleObj"]] <- createJaspState(out, dependencies = "lambda2Scale")
   }
   return(out)
 }
@@ -307,26 +242,10 @@
     out <- list()
   # is coefficient even checked?
   if (options[["lambda6Scale"]]  && is.null(model[["empty"]])) {
-
-    out[["est"]] <- Bayesrel:::applylambda6(model[["data_cov"]])
-    if (is.na(out[["est"]])) {
-      out[["error"]] <- gettext("Lambda6 calculation failed")
-    } else {
-      # do we need an interval estimate?
-      if (options[["intervalOn"]]) {
-
-        ciValue <- options[["confidenceIntervalValue"]]
-
-        if (is.null(out[["samp"]])) {
-          startProgressbar(options[["noSamples"]])
-          out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applylambda6, callback = progressbarTick)
-        }
-
-        if (sum(!is.na(out[["samp"]])) < 3)
-          out[["error"]] <- gettext("Lambda6 interval calculation failed")
-        else
-          out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
-
+    if (options[["intervalOn"]]) {
+      if (is.null(out[["samp"]])) {
+        startProgressbar(options[["noSamples"]])
+        out[["samp"]] <- apply(model[["bootSamp"]], 1, Bayesrel:::applylambda6, callback = progressbarTick)
       }
     }
 
@@ -334,8 +253,7 @@
       return(out)
 
     stateContainer <- .getStateContainerF(jaspResults)
-    stateContainer[["lambda6ScaleObj"]] <- createJaspState(out,
-                                                           dependencies = c("lambda6Scale", "confidenceIntervalValue"))
+    stateContainer[["lambda6ScaleObj"]] <- createJaspState(out, dependencies = "lambda6Scale")
   }
   return(out)
 }
@@ -358,9 +276,10 @@
 
     if (is.null(out[["itemDropped"]]))
       out[["itemDropped"]] <- .freqItemDroppedStats(model[["data_cov"]], Bayesrel:::applylambda6)
-    if (anyNA(out[["itemDropped"]]))
-      out[["error"]] <- gettext("Lambda6 item dropped statistics failed")
-
+    if (anyNA(out[["itemDropped"]])) {
+      out[["error"]] <- gettext("Lambda6 item dropped statistics failed.")
+      out[["itemDropped"]] <- rep(NaN, ncol(dataset))
+    }
     if (options[["disableSampleSave"]])
       return(out)
 
@@ -382,32 +301,23 @@
     out <- list()
   # is coefficient even checked?
   if (options[["glbScale"]]  && is.null(model[["empty"]])) {
-
-    out[["est"]] <- Bayesrel:::glbOnArrayCustom(model[["data_cov"]])
-
-
     # do we need an interval estimate?
     if (options[["intervalOn"]]) {
-      ciValue <- options[["confidenceIntervalValue"]]
       if (is.null(out[["samp"]])) {
         startProgressbar(4)
         out[["samp"]] <- Bayesrel:::glbOnArrayCustom(model[["bootSamp"]], callback = progressbarTick)
-
       }
-      out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
     }
 
     if (options[["disableSampleSave"]])
       return(out)
 
     stateContainer <- .getStateContainerF(jaspResults)
-    stateContainer[["glbScaleObj"]] <- createJaspState(out,
-                                                       dependencies = c("glbScale", "confidenceIntervalValue"))
+    stateContainer[["glbScaleObj"]] <- createJaspState(out, dependencies = "glbScale")
   }
   return(out)
 }
 
-# check the error handling of the glb !!!!!!!!
 .frequentistGlbItem <- function(jaspResults, dataset, options, model) {
 
   if (!is.null(.getStateContainerF(jaspResults)[["glbItemObj"]]$object))
@@ -454,12 +364,7 @@
     out <- list()
   # is coefficient even checked?
   if (options[["averageInterItemCor"]] && is.null(model[["empty"]])) {
-    ciValue <- options[["confidenceIntervalValue"]]
-
-    out[["est"]] <- mean(model[["data_cor"]][lower.tri(model[["data_cor"]])])
-
     if (options[["intervalOn"]]) {
-
       if (is.null(out[["samp"]])) {
         startProgressbar(options[["noSamples"]])
         out[["samp"]] <- numeric(options[["noSamples"]])
@@ -468,7 +373,6 @@
           out[["samp"]][i] <- mean(corm[lower.tri(corm)])
         }
       }
-      out[["conf"]] <- quantile(out[["samp"]], probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
     }
 
     if (options[["disableSampleSave"]])
@@ -476,7 +380,7 @@
 
     stateContainer <- .getStateContainerF(jaspResults)
     stateContainer[["avgObj"]] <- createJaspState(out,
-                                                  dependencies = c("averageInterItemCor", "confidenceIntervalValue"))
+                                                  dependencies = c("averageInterItemCor"))
   }
   return(out)
 }
@@ -609,4 +513,176 @@
     stateContainer[["sdItemObj"]] <- createJaspState(out, dependencies = "sdItem")
   }
   return(out)
+}
+
+
+
+
+.frequentistComputeScaleResults <- function(jaspResults, dataset, options, model) {
+  if (!is.null(.getStateContainerF(jaspResults)[["scaleResultsObj"]]$object))
+    return(.getStateContainerF(jaspResults)[["scaleResultsObj"]]$object)
+
+  out <- model[["scaleResults"]]
+  if (is.null(out))
+    out <- list()
+
+  if (is.null(model[["empty"]])) {
+
+    ciValue <- options[["confidenceIntervalValue"]]
+
+    # go one coefficient at a time, because there are too many special options for a generic solution
+    # #### omega ####
+    if (options[["omegaScale"]]) {
+      if (options[["omegaMethod"]] == "cfa") {
+        dataset <- scale(dataset, scale = FALSE)
+        omegaO <- Bayesrel:::omegaFreqData(dataset, interval = ciValue, omega.int.analytic = TRUE,
+                                           pairwise = model[["pairwise"]])
+        if (is.na(omegaO[["omega"]])) {
+          out[["error"]][["omegaScale"]] <- gettext("Omega calculation with CFA failed.
+                                                    Try changing to PFA in Advanced Options")
+          out[["est"]][["omegaScale"]] <- NaN
+        } else {
+          out[["fit"]][["omegaScale"]] <- omegaO[["indices"]]
+          out[["est"]][["omegaScale"]] <- omegaO[["omega"]]
+
+          if (options[["intervalOn"]]) {
+            if (options[["omegaInterval"]] == "omegaAnalytic") {
+              out[["conf"]][["omegaScale"]] <- c(omegaO$omega_lower, omegaO$omega_upper)
+            } else { # omega interval bootstrapped
+              if (!is.null(model[["omegaScale"]][["samp"]])) {
+                if (sum(!is.na(model[["omegaScale"]][["samp"]])) >= 2) {
+                  out[["conf"]][["omegaScale"]] <- quantile(model[["omegaScale"]][["samp"]],
+                                                            probs = c((1 - ciValue)/2, 1 - (1 - ciValue) / 2),
+                                                            na.rm = TRUE)
+                } else {
+                  out[["error"]][["omegaScale"]] <- gettext("Omega bootstrapped interval calculation with CFA failed.
+                                                            Try changing to PFA in 'Advanced Options'")
+                  out[["conf"]][["omegaScale"]] <- NaN
+                }
+              }
+            }
+          }
+        }
+      } else { # omega method is pfa
+        out[["est"]][["omegaScale"]] <- Bayesrel:::applyomegaPFA(model[["data_cov"]])
+        if (is.na(out[["est"]][["omegaScale"]])) {
+          out[["error"]][["omegaScale"]] <- gettext("Omega calculation with PFA failed.")
+          out[["est"]][["omegaScale"]] <- NaN
+        } else {
+          if (options[["intervalOn"]]) {
+            if (!is.null(model[["omegaScale"]][["samp"]])) {
+              if (sum(!is.na(model[["omegaScale"]][["samp"]])) >= 2) {
+                out[["conf"]][["omegaScale"]] <- quantile(model[["omegaScale"]][["samp"]],
+                                                          probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2),
+                                                          na.rm = TRUE)
+              } else {
+                out[["error"]][["omegaScale"]] <- gettext("Omega interval calculation with PFA failed.")
+                out[["conf"]][["omegaScale"]] <- NaN
+              }
+            }
+          }
+        }
+      }
+    }
+
+    # #### alpha ####
+    if (options[["alphaScale"]]) {
+      # alpha unstandardized
+      if (options[["alphaMethod"]] == "alphaUnstand") {
+        out[["est"]][["alphaScale"]] <- Bayesrel:::applyalpha(model[["data_cov"]])
+        if (options[["intervalOn"]]) {
+          # should the interval be analytic
+          if (options[["alphaInterval"]] == "alphaAnalytic") {
+            out[["conf"]][["alphaScale"]] <- Bayesrel:::ciAlpha(1 - ciValue, model[["n"]], model[["data_cov"]])
+          } else { # alpha interval bootstrapped
+            if (!is.null(model[["alphaScale"]][["samp"]])) {
+              out[["conf"]][["alphaScale"]] <- quantile(model[["alphaScale"]][["samp"]],
+                                                        probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2),
+                                                        na.rm = TRUE)
+            }
+          }
+        }
+      } else { # alpha standardized
+        ccor <- model[["data_cor"]]
+        out[["est"]][["alphaScale"]] <- Bayesrel:::applyalpha(ccor)
+        if (options[["intervalOn"]]) {
+          # should the interval be analytic
+          if (options[["alphaInterval"]] == "alphaAnalytic") {
+            out[["conf"]][["alphaScale"]] <- Bayesrel:::ciAlpha(1 - ciValue, model[["n"]], ccor)
+          } else {
+            if (!is.null(model[["alphaScale"]][["sampCor"]])) {
+              out[["conf"]][["alphaScale"]] <- quantile(model[["alphaScale"]][["sampCor"]],
+                                                        probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2),
+                                                        na.rm = TRUE)
+            }
+          }
+        }
+      }
+    }
+
+    # #### lambda 6 ####
+    if (options[["lambda6Scale"]]) {
+      out[["est"]][["lambda6Scale"]] <- Bayesrel:::applylambda6(model[["data_cov"]])
+      if (is.na(out[["est"]][["lambda6Scale"]])) {
+        out[["error"]][["lambda6Scale"]] <- gettext("Lambda6 calculation failed.")
+      }
+      if (options[["intervalOn"]]) {
+        if (sum(!is.na(model[["lambda6Scale"]][["samp"]])) >= 2) {
+          out[["conf"]][["lambda6Scale"]] <- quantile(model[["lambda6Scale"]][["samp"]],
+                                                      probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2), na.rm = TRUE)
+        } else {
+          out[["error"]][["lambda6Scale"]] <- gettext("Lambda6 interval calculation failed.")
+        }
+
+      }
+    }
+
+    if (options[["intervalOn"]]) {
+      # the intervals for coefficients with bootstrap samples can be done generic
+      bootCoeffs <- c("lambda2Scale", "glbScale", "averageInterItemCor")
+      selected <- bootCoeffs[bootCoeffs %in% names(which(model[["derivedOptions"]][["selectedEstimators"]]))]
+
+      samps <- model[selected]
+      samps <- lapply(samps, function(x) x[["samp"]])
+      out[["conf"]][selected] <- lapply(samps, function(x) {quantile(x, probs = c((1 - ciValue) / 2, 1 - (1 - ciValue) / 2),
+                                                                     na.rm = TRUE)})
+    }
+
+    # point estimates
+    if (options[["lambda2Scale"]]) {
+      out[["est"]][["lambda2Scale"]] <- Bayesrel:::applylambda2(model[["data_cov"]])
+    }
+    if (options[["glbScale"]]) {
+      out[["est"]][["glbScale"]] <- Bayesrel:::glbOnArrayCustom(model[["data_cov"]])
+    }
+    if (options[["averageInterItemCor"]]) {
+      out[["est"]][["averageInterItemCor"]] <- mean(model[["data_cor"]][lower.tri(model[["data_cor"]])])
+    }
+
+    # just copying for mean and sd
+    if (options[["meanScale"]]) {
+      out[["est"]][["meanScale"]] <- model[["meanScale"]][["est"]]
+      out[["conf"]][["meanScale"]] <- model[["meanScale"]][["conf"]]
+    }
+    if (options[["sdScale"]]) {
+      out[["est"]][["sdScale"]] <- model[["sdScale"]][["est"]]
+      out[["conf"]][["sdScale"]] <- model[["sdScale"]][["conf"]]
+    }
+
+
+    stateContainer <- .getStateContainerF(jaspResults)
+    stateContainer[["scaleResultsObj"]] <- createJaspState(out, dependencies = c("confidenceIntervalValue",
+                                                                                 "meanScale", "sdScale",
+                                                                                 "alphaScale", "omegaScale",
+                                                                                 "lambda2Scale", "lambda6Scale",
+                                                                                 "glbScale","averageInterItemCor",
+                                                                                 "meanMethod", "sdMethod",
+                                                                                 "omegaMethod", "omegaInterval",
+                                                                                 "alphaInterval", "alphaMethod"))
+
+
+  }
+
+  return(out)
+
 }

--- a/R/uniDimFrequentistOutputTables.R
+++ b/R/uniDimFrequentistOutputTables.R
@@ -3,12 +3,13 @@
 .frequentistScaleTable <- function(jaspResults, model, options) {
 
   if (!is.null(.getStateContainerF(jaspResults)[["scaleTable"]]$object))
-      return()
+    return()
 
   scaleTable <- createJaspTable(gettext("Frequentist Scale Reliability Statistics"))
 
   scaleTable$dependOn(options = c("omegaScale", "alphaScale", "lambda2Scale", "lambda6Scale", "glbScale",
-                                  "averageInterItemCor", "meanScale", "sdScale", "meanMethod", "sdMethod"))
+                                  "averageInterItemCor", "meanScale", "sdScale", "meanMethod", "sdMethod",
+                                  "omegaMethod", "omegaInterval", "alphaMethod", "alphaInterval"))
   scaleTable$addColumnInfo(name = "estimate", title = gettext("Estimate"), type = "string")
 
   if (options[["intervalOn"]]) {
@@ -25,13 +26,11 @@
   stateContainer <- .getStateContainerF(jaspResults)
   stateContainer[["scaleTable"]] <- scaleTable
 
-  if (!is.null(model[["omegaScale"]][["error"]])) {
-    scaleTable$setError(model[["omegaScale"]][["error"]])
-    return()
+  if (!is.null(model[["scaleResults"]][["error"]][["omegaScale"]])) {
+    model[["footnote"]] <- paste(model[["footnote"]], model[["scaleResults"]][["error"]][["omegaScale"]])
   }
-  if (!is.null(model[["lambda6Scale"]][["error"]])) {
-    scaleTable$setError(model[["lambda6Scale"]][["error"]])
-    return()
+  if (!is.null(model[["scaleResults"]][["error"]][["lambda6Scale"]])) {
+    model[["footnote"]] <- paste(model[["footnote"]], model[["scaleResults"]][["error"]][["lambda6Scale"]])
   }
 
   derivedOptions <- model[["derivedOptions"]]
@@ -62,8 +61,8 @@
       nm <- names(idxSelected[j])
 
       scaleTable$addColumnInfo(name = paste0("est", i), title = opts[i], type = "number")
-      newData <- data.frame(est = c(unlist(model[[nm]][["est"]], use.names = FALSE),
-                                    unlist(model[[nm]][["conf"]], use.names = FALSE)))
+      newData <- data.frame(est = c(unlist(model[["scaleResults"]][["est"]][[nm]], use.names = FALSE),
+                                    unlist(model[["scaleResults"]][["conf"]][[nm]], use.names = FALSE)))
       colnames(newData) <- paste0(colnames(newData), i)
       allData <- cbind(allData, newData)
     }
@@ -73,7 +72,7 @@
       nm <- names(idxSelected[j])
 
       scaleTable$addColumnInfo(name = paste0("est", i), title = opts[i], type = "number")
-      newData <- data.frame(est = c(unlist(model[[nm]][["est"]], use.names = FALSE)))
+      newData <- data.frame(est = c(unlist(model[["scaleResults"]][["est"]][[nm]], use.names = FALSE)))
       colnames(newData) <- paste0(colnames(newData), i)
       allData <- cbind(allData, newData)
     }
@@ -111,13 +110,13 @@
   stateContainer <- .getStateContainerF(jaspResults)
   stateContainer[["itemTable"]] <- itemTable
 
+  footnote <- ""
+
   if (!is.null(model[["omegaItem"]][["error"]])) {
-    itemTable$setError(model[["omegaItem"]][["error"]])
-    return()
+    footnote <- paste(footnote, model[["omegaItem"]][["error"]])
   }
   if (!is.null(model[["lambda6Item"]][["error"]])) {
-    itemTable$setError(model[["lambda6Item"]][["error"]])
-    return()
+    footnote <- paste(footnote, model[["omegaItem"]][["error"]])
   }
 
   selected <- derivedOptions[["itemDroppedSelected"]]
@@ -126,7 +125,6 @@
   idxSelected <- which(selected)
   coefficients <- derivedOptions[["namesEstimators"]][["coefficients"]]
 
-  footnote <- ""
 
   if (length(model[["itemsDropped"]]) > 0) {
     itemTable[["variable"]] <- model[["itemsDropped"]]
@@ -175,8 +173,8 @@
 # once the package is updated check this again and apply:
 .frequentistSingleFactorFitTable <- function(jaspResults, model, options) {
 
-  if (!is.null(.getStateContainerF(jaspResults)[["fitTable"]]$object) || is.null(model[["omegaScale"]][["omegaFit"]]) ||
-      !options[["fitMeasures"]])
+  if (!is.null(.getStateContainerF(jaspResults)[["fitTable"]]$object) ||
+      is.null(model[["scaleResults"]][["fit"]][["omegaScale"]]) || !options[["fitMeasures"]])
     return()
 
   fitTable <- createJaspTable(gettextf("Fit Measures of Single Factor Model Fit"))
@@ -187,7 +185,7 @@
   opts <- c("Chi-Square", "df", "p.value", "RMSEA", "Lower CI RMSEA", "Upper CI RMSEA", "SRMR")
   allData <- data.frame(
     measure = opts,
-    value = as.vector(model[["omegaScale"]][["omegaFit"]])
+    value = as.vector(model[["scaleResults"]][["fit"]][["omegaScale"]])
   )
   fitTable$setData(allData)
 


### PR DESCRIPTION
improves the speed by:
fixes https://github.com/jasp-stats/jasp-test-release/issues/1399

the changes are relatively extensive, since the calculation of each coefficient indicators (point estimate, interval bounds) were separated from the computation of the coefficient samples (both bootstrapped and posterior.

Also the red error box when omega or lambda6 failed in the frequentist analysis is now replaced with a table footnote and `NaN` in the table cells