### PR TITLE
fix mean and sd method bug

### DIFF
--- a/R/uniDimBayesianCalcCoeff.R
+++ b/R/uniDimBayesianCalcCoeff.R
@@ -575,7 +575,7 @@
                                                                                  "alphaScale", "omegaScale",
                                                                                  "lambda2Scale", "lambda6Scale",
                                                                                  "glbScale","averageInterItemCor",
-                                                                                 "meanMethod", "sdMethod"))
+                                                                                 "scoresMethod"))
 
   }
 

--- a/R/uniDimBayesianOutputTables.R
+++ b/R/uniDimBayesianOutputTables.R
@@ -8,7 +8,7 @@
   scaleTable <- createJaspTable(gettext("Bayesian Scale Reliability Statistics"))
   scaleTable$dependOn(options = c("credibleIntervalValueScale", "meanScale", "sdScale", "rHat",
                                   "alphaScale", "omegaScale", "lambda2Scale", "lambda6Scale", "glbScale",
-                                  "averageInterItemCor", "meanMethod", "sdMethod"))
+                                  "averageInterItemCor", "scoresMethod"))
 
   scaleTable$addColumnInfo(name = "estimate", title = gettext("Estimate"), type = "string")
 

--- a/R/uniDimFrequentistCalcCoeff.R
+++ b/R/uniDimFrequentistCalcCoeff.R
@@ -676,7 +676,7 @@
                                                                                  "alphaScale", "omegaScale",
                                                                                  "lambda2Scale", "lambda6Scale",
                                                                                  "glbScale","averageInterItemCor",
-                                                                                 "meanMethod", "sdMethod",
+                                                                                 "scoresMethod",
                                                                                  "omegaMethod", "omegaInterval",
                                                                                  "alphaInterval", "alphaMethod"))
 

--- a/R/uniDimFrequentistOutputTables.R
+++ b/R/uniDimFrequentistOutputTables.R
@@ -8,7 +8,7 @@
   scaleTable <- createJaspTable(gettext("Frequentist Scale Reliability Statistics"))
 
   scaleTable$dependOn(options = c("omegaScale", "alphaScale", "lambda2Scale", "lambda6Scale", "glbScale",
-                                  "averageInterItemCor", "meanScale", "sdScale", "meanMethod", "sdMethod",
+                                  "averageInterItemCor", "meanScale", "sdScale", "scoresMethod",
                                   "omegaMethod", "omegaInterval", "alphaMethod", "alphaInterval"))
   scaleTable$addColumnInfo(name = "estimate", title = gettext("Estimate"), type = "string")
 

--- a/inst/Upgrades.qml
+++ b/inst/Upgrades.qml
@@ -43,6 +43,14 @@ Upgrades
 			to:		"lambda6Scale"
 		} // for 0.15 the coefficient name changed again.
 
+		ChangeSetValue
+		{
+			condition:	function(options) { return options["scoresMethod"] === undefined }
+			name:		"scoresMethod"
+			jsonValue:	"meanScores"
+		} // in older jasp versions there were no mean and sd options (rowSums and rowMeans),
+		// just the colMeans. This way, the refreshed result is closer to the old versions
+
 		ChangeRename
 		{
 			from:	"mcDonaldItem"
@@ -147,6 +155,15 @@ Upgrades
 			from:	"guttman6Scale"
 			to:		"lambda6Scale"
 		}
+
+		ChangeSetValue
+		{
+			condition:	function(options) { return options["scoresMethod"] === undefined }
+			name:		"scoresMethod"
+			jsonValue:	"meanScores"
+		} // in older jasp versions there were no mean and sd options (rowSums and rowMeans),
+		// just the colMeans. This way, the refreshed result is closer to the old versions
+
 		ChangeRename
 		{
 			from:	"mcDonaldItem"


### PR DESCRIPTION
When changing the method of the mean and sd from sumScores to meanScores or the other way around the output table wasn't updated, and the sumScores option was always displayed. This fixes it.
Also in old jasp versions the mean and sd were calculated for colMeans, this upgrades to the rowMeans now, since the colMeans are not used anymore.