### PR TITLE
Restructures the fit measures for the Bayesian single factor model

### DIFF
--- a/R/helpFunsBayesian.R
+++ b/R/helpFunsBayesian.R
@@ -173,9 +173,10 @@
 }
 
 
-.LRblav <- function(data, cmat, basell) {
+.LRblav <- function(data, cmat, basell, callback = function(){}) {
   tmpll <- .dmultinorm(data, cmat)
   out <- 2 * (basell - sum(tmpll))
+  callback()
   return(out)
 }
 

--- a/R/uniDimBayesianCalcCoeff.R
+++ b/R/uniDimBayesianCalcCoeff.R
@@ -687,7 +687,7 @@
 
     lsm <- apply(model[["singleFactor"]][["loadings"]], 3, mean)
     psm <- apply(model[["singleFactor"]][["residuals"]], 3, mean)
-    implM <- lsm %*% t(lsm) + diag(psm) # mean implied covariance matrix
+    implM <- tcrossprod(lsm) + diag(psm) # mean implied covariance matrix
     Dtm <- .LRblav(dataset, implM, LL1) # deviance of the mean model implied cov matrix
     out[["lr"]] <- Dtm
 

--- a/R/uniDimBayesianCalcCoeff.R
+++ b/R/uniDimBayesianCalcCoeff.R
@@ -685,12 +685,13 @@
     psm <- apply(model[["singleFactor"]][["residuals"]], 3, mean)
     implM <- lsm %*% t(lsm) + diag(psm) # mean implied covariance matrix
     Dtm <- .LRblav(dataset, implM, LL1) # deviance of the mean model implied cov matrix
-    out[["B-LR"]] <- Dtm
+    out[["lr"]] <- Dtm
 
+    out[["srmr"]] <- .SRMR(cdat, implM)
     ### BRMSEA ###
     Dm <- mean(LR_obs) # mean deviance of the model implied cov matrices
     pD <- Dm - Dtm # effective number of parameters (free parameters)
-    out[["B-RMSEA"]] <- .BRMSEA(LR_obs, pstar, pD, n)
+    out[["rmsea"]] <- .BRMSEA(LR_obs, pstar, pD, n)
     # rmsea_m <- sqrt((Dtm - (pstar - pD)) / ((pstar - pD) * n))
 
     startProgressbar(options[["noSamples"]] * options[["noChains"]])
@@ -730,8 +731,8 @@
     cfis[cfis > 1] <- 1
     tlis[tlis > 1] <- 1
 
-    out[["B-CFI"]] <- cfis
-    out[["B-TLI"]] <- tlis
+    out[["cfi"]] <- cfis
+    out[["tli"]] <- tlis
 
 
     stateContainer <- .getStateContainerB(jaspResults)

--- a/R/uniDimBayesianOutputTables.R
+++ b/R/uniDimBayesianOutputTables.R
@@ -253,7 +253,7 @@
 
 
 ###############################################
-# use 'posterior mean and median in the table, also flip the table
+# use posterior mean and median in the table, also flip the table
 ###############################################
 
 .BayesianFitMeasuresTable <- function(jaspResults, model, options) {
@@ -283,13 +283,15 @@
 
   if (options[["omegaScale"]] && options[["fitMeasures"]] && is.null(model[["empty"]])) {
 
-    pointEsts <- sapply(model[["fitMeasures"]], .getPointEstFun(options[["pointEst"]]))
+    pointEsts <- vapply(model[["fitMeasures"]], .getPointEstFun(options[["pointEst"]]), numeric(1))
 
-    creds <- sapply(model[["fitMeasures"]][3:5], function(x) coda::HPDinterval(coda::mcmc(c(x))))
+    creds <- vapply(model[["fitMeasures"]][3:5], function(x) coda::HPDinterval(coda::mcmc(c(x))), numeric(2))
     creds <- cbind(matrix(NA_real_, 2, 2), creds) # no entry for LR and SRMR
 
-    cutoffs_saturated <- sapply(model[["fitMeasures"]][3], function(x) mean(x < options[["fitCutoffSat"]]))
-    cutoffs_null <- sapply(model[["fitMeasures"]][-(1:3)], function(x) mean(x > options[["fitCutoffNull"]]))
+    cutoffs_saturated <- vapply(model[["fitMeasures"]][3], function(x) mean(x < options[["fitCutoffSat"]]),
+                                numeric(1))
+    cutoffs_null <- vapply(model[["fitMeasures"]][-(1:3)], function(x) mean(x > options[["fitCutoffNull"]]),
+                           numeric(1))
     cutoffs <- c(NA_real_, NA_real_, cutoffs_saturated, cutoffs_null) # no entry for LR and SRMR
 
     df <- data.frame(estimate = c(pointEst, intervalLow, intervalUp, "Relative to cutoff"))

--- a/R/uniDimBayesianOutputTables.R
+++ b/R/uniDimBayesianOutputTables.R
@@ -266,31 +266,38 @@
   fitTable$dependOn(options = c("omegaScale", "fitMeasures", "fitCutoffSat", "fitCutoffNull", "pointEst",
                                 "credibleIntervalValueFitMeasures"))
 
-  cred <- format(100 * options[["credibleIntervalValueFitMeasures"]], digits = 3, drop0trailing = TRUE)
+  fitTable$addColumnInfo(name = "estimate", title = gettext("Estimate"), type = "string")
 
-  fitTable$addColumnInfo(name = "measure", title = gettext("Fit measure"), type = "string")
-  fitTable$addColumnInfo(name = "pointEst", title = gettext("Point estimate"), type = "number")
-  fitTable$addColumnInfo(name = "lower", title = gettextf("Lower %s%% CI", cred), type = "number")
-  fitTable$addColumnInfo(name = "upper", title = gettextf("Upper %s%% CI", cred), type = "number")
-  fitTable$addColumnInfo(name = "cutoff", title = gettext("Relative to cutoff"), type = "number")
+  fitTable$addColumnInfo(name = "lr", title = "B-LR", type = "number")
+  fitTable$addColumnInfo(name = "srmr", title = "B-SRMR", type = "number")
+  fitTable$addColumnInfo(name = "rmsea", title = "B-RMSEA", type = "number")
+  fitTable$addColumnInfo(name = "cfi", title = "B-CFI", type = "number")
+  fitTable$addColumnInfo(name = "tli", title = "B-TLI", type = "number")
 
+  cred <- gettextf("%s%% CI",
+                       format(100 * options[["credibleIntervalValueFitMeasures"]], digits = 3, drop0trailing = TRUE))
+  intervalLow <- gettextf("%s lower bound", cred)
+  intervalUp <- gettextf("%s upper bound", cred)
+
+  pointEst <- gettextf("Posterior %s", options[["pointEst"]])
 
   if (options[["omegaScale"]] && options[["fitMeasures"]] && is.null(model[["empty"]])) {
 
     pointEsts <- sapply(model[["fitMeasures"]], .getPointEstFun(options[["pointEst"]]))
 
-    creds <- sapply(model[["fitMeasures"]][2:4], function(x) coda::HPDinterval(coda::mcmc(c(x))))
-    creds <- cbind(NA_real_, creds) # no entry for LR
+    creds <- sapply(model[["fitMeasures"]][3:5], function(x) coda::HPDinterval(coda::mcmc(c(x))))
+    creds <- cbind(matrix(NA_real_, 2, 2), creds) # no entry for LR and SRMR
 
-    cutoffs_saturated <- sapply(model[["fitMeasures"]][2], function(x) mean(x < options[["fitCutoffSat"]]))
-    cutoffs_null <- sapply(model[["fitMeasures"]][-(1:2)], function(x) mean(x > options[["fitCutoffNull"]]))
-    cutoffs <- c(NA_real_, cutoffs_saturated, cutoffs_null) # no entry for LR
+    cutoffs_saturated <- sapply(model[["fitMeasures"]][3], function(x) mean(x < options[["fitCutoffSat"]]))
+    cutoffs_null <- sapply(model[["fitMeasures"]][-(1:3)], function(x) mean(x > options[["fitCutoffNull"]]))
+    cutoffs <- c(NA_real_, NA_real_, cutoffs_saturated, cutoffs_null) # no entry for LR and SRMR
 
-    df <- data.frame(measure = names(model[["fitMeasures"]]), pointEst = pointEsts,
-                     lower = creds[1, ], upper = creds[2, ], cutoff = cutoffs)
+    df <- data.frame(estimate = c(pointEst, intervalLow, intervalUp, "Relative to cutoff"))
+    dfnums <- rbind(pointEsts, creds, cutoffs)
+    df <- cbind(df, dfnums)
     fitTable$setData(df)
 
-    fitTable$addFootnote(gettext("'Relative to cutoff'-column denotes the probability that the B-RMSEA is smaller than
+    fitTable$addFootnote(gettext("'Relative to cutoff'-row denotes the probability that the B-RMSEA is smaller than
                          the corresponding cutoff and the probabilities that the B-CFI/TLI are larger than the
                          corresponding cutoff."))
 

--- a/R/uniDimFrequentistOutputTables.R
+++ b/R/uniDimFrequentistOutputTables.R
@@ -182,7 +182,7 @@
   fitTable$addColumnInfo(name = "measure", title = gettext("Fit measure"),   type = "string")
   fitTable$addColumnInfo(name = "value",  title = gettext("Value"), type = "number")
 
-  opts <- c("Chi-Square", "df", "p.value", "RMSEA", "Lower CI RMSEA", "Upper CI RMSEA", "SRMR")
+  opts <- c("Chi-Square", "df", "p.value", "RMSEA", "Lower 90% CI RMSEA", "Upper 90% CI RMSEA", "SRMR")
   allData <- data.frame(
     measure = opts,
     value = as.vector(model[["scaleResults"]][["fit"]][["omegaScale"]])

--- a/inst/qml/uniDimBayesian.qml
+++ b/inst/qml/uniDimBayesian.qml
@@ -487,6 +487,13 @@ Form
 				name:		"fitMeasures"
 				label:		qsTr("Fit measures");
 
+				CIField
+				{
+					name:			"credibleIntervalValueFitMeasures";
+					label:			qsTr("Credible interval");
+					defaultValue:	90
+				}
+
 				DoubleField
 				{
 					name:			"fitCutoffSat"

--- a/tests/testthat/test-reliabilityUniDimBayesian.R
+++ b/tests/testthat/test-reliabilityUniDimBayesian.R
@@ -498,13 +498,15 @@ options$dispPPC <- TRUE
 set.seed(1)
 results <- runAnalysis("reliabilityUniDimBayesian", "asrm.csv", options)
 
+
 test_that("Fit Measures for the Single-Factor Model table results match", {
   table <- results[["results"]][["stateContainer"]][["collection"]][["stateContainer_fitTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                                 list("", "", "B-LR", 13.0900880096089, "", 0.215555555555556, 0.0233139770705626,
-                                      "B-RMSEA", 0.1319747009136, 0.222796365776379, 0.946666666666667,
-                                      0.845602177064211, "B-CFI", 0.929544182303969, 1, 0.595555555555556,
-                                      0.693722044278387, "B-TLI", 0.860237253334787, 1))
+                                 list(0.929544182303969, "Posterior mean", 13.0900880096089, 0.1319747009136,
+                                      0.061860112775025, 0.860237253334787, 0.845602177064211, "90% CI lower bound",
+                                      "", 0.0233139770705626, "", 0.693722044278387, 1, "90% CI upper bound",
+                                      "", 0.222796365776379, "", 1, 0.946666666666667, "Relative to cutoff",
+                                      "", 0.215555555555556, "", 0.595555555555556))
 })
 
 test_that("Posterior Predictive Check Omega plot matches", {

--- a/tests/testthat/test-reliabilityUniDimBayesian.R
+++ b/tests/testthat/test-reliabilityUniDimBayesian.R
@@ -498,13 +498,13 @@ options$dispPPC <- TRUE
 set.seed(1)
 results <- runAnalysis("reliabilityUniDimBayesian", "asrm.csv", options)
 
-
-test_that("Fit for the Single-Factor Model results match", {
+test_that("Fit Measures for the Single-Factor Model table results match", {
   table <- results[["results"]][["stateContainer"]][["collection"]][["stateContainer_fitTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
-                                 list("", "B-LR", 13.0900880096089, 0.215555555555556, "B-RMSEA", 0.1319747009136,
-                                      0.946666666666667, "B-CFI", 0.929544182303969, 0.595555555555556,
-                                      "B-TLI", 0.860237253334787))
+                                 list("", "", "B-LR", 13.0900880096089, "", 0.215555555555556, 0.0233139770705626,
+                                      "B-RMSEA", 0.1319747009136, 0.222796365776379, 0.946666666666667,
+                                      0.845602177064211, "B-CFI", 0.929544182303969, 1, 0.595555555555556,
+                                      0.693722044278387, "B-TLI", 0.860237253334787, 1))
 })
 
 test_that("Posterior Predictive Check Omega plot matches", {

--- a/tests/testthat/test-reliabilityUniDimFrequentist.R
+++ b/tests/testthat/test-reliabilityUniDimFrequentist.R
@@ -124,8 +124,8 @@ test_that("Frequentist omega results match for CFA with bootstrapping", {
   table <- results[["results"]][["stateContainer"]][["collection"]][["stateContainer_fitTable"]][["data"]]
   jaspTools::expect_equal_tables(table,
                                  list("Chi-Square", 12.788508304247, "df", 5, "p.value", 0.0254433712709828,
-                                      "RMSEA", 0.15724319758923, "Lower CI RMSEA", 0.0507316506074521,
-                                      "Upper CI RMSEA", 0.266560548199575, "SRMR", 0.0708026289801857
+                                      "RMSEA", 0.15724319758923, "Lower 90% CI RMSEA", 0.0507316506074521,
+                                      "Upper 90% CI RMSEA", 0.266560548199575, "SRMR", 0.0708026289801857
                                  ))
 
   table <- results[["results"]][["stateContainer"]][["collection"]][["stateContainer_scaleTable"]][["data"]]


### PR DESCRIPTION
before: 
![Screenshot 2022-02-03 at 16 03 28](https://user-images.githubusercontent.com/38500953/152372600-3a71a8e1-88f0-4a7c-83db-d574cfdfc74a.png)

after:
![Screenshot 2022-02-03 at 16 23 31](https://user-images.githubusercontent.com/38500953/152372644-c9075e93-b639-4ea7-bbaf-f82a727f2e3d.png)

the table is flipped so it is more consistent with the other results table, and it offers a CI for the RMSEA, CFI, and TLI