### PR TITLE
remove Bayesrel github remote, use CRAN instead

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: jaspReliability
 Type: Package
 Title: Reliability Module for JASP
 Version: 0.16.1
-Date: 2021-11-16
+Date: 2022-02-10
 Author: Julius M. Pfadt, Don van den Bergh & Eric-Jan Wagenmakers
 Website: https://github.com/jasp-stats/Reliability
 Maintainer: Julius M. Pfadt <julius.pfadt@gmail.com>
@@ -21,6 +21,5 @@ Imports:
   psych,
   lme4
 Remotes:
-  juliuspf/Bayesrel@68156bc9427f6e4545ee340d291d4cada729df30,
   jasp-stats/jaspBase,
   jasp-stats/jaspGraphs

--- a/inst/help/toolTip/sampleSavingBayes.md
+++ b/inst/help/toolTip/sampleSavingBayes.md
@@ -1,0 +1,3 @@
+
+## Disable the saving of posterior MCMC samples
+In case you want to save space for your output file, you can check this box. Beware that this will also lead to a loss in speed for the analysis. This happens because some samples inside the reliability module are precomputed and stored, so that the analysis can move forward in a much faster way. However, this also results in an increased size of the output object, and if you decide to save your analysis the resulting file will contain these samples. If you decide to run the analysis with a large number of iterations you might want to check that box if you do not want an increased file size for your output. 

--- a/inst/help/toolTip/sampleSavingFreq.md
+++ b/inst/help/toolTip/sampleSavingFreq.md
@@ -1,0 +1,3 @@
+
+## Disable the saving of bootstrap samples
+In case you want to save space for your output file, you can check this box. Beware that this will also lead to a loss in speed for the analysis. This happens because some samples inside the reliability module are precomputed and stored, so that the analysis can move forward in a much faster way. However, this also results in an increased size of the output object, and if you decide to save your analysis the resulting file will contain these samples. If you decide to run the analysis with a large number of bootstrap samples you might want to check that box if you do not want an increased file size for your output. 


### PR DESCRIPTION
also re-adds the tooltip .md files for "disable saving samples" that were somehow deleted by accident in a previous PR (by me)
fixes https://github.com/jasp-stats/jasp-issues/issues/1621