### PR TITLE
Don't translate a placeholder

### DIFF
--- a/R/unidimensionalReliabilityFrequentist.R
+++ b/R/unidimensionalReliabilityFrequentist.R
@@ -1193,13 +1193,9 @@ gettextf <- function(fmt, ..., domain = NULL)  {
     cr <- cor(dataset, use = "pairwise.complete.obs")
     cr[lower.tri(cr, diag = TRUE)] <- 0
     pos <- which(round(cr, 3) == 1, arr.ind = TRUE)
-    if (length(pos) == 0) {
-      footnote <- footnote
-    } else {
-      for (i in seq_len(nrow(pos))) {
-        footnote <- gettextf("%1$s Variables %2$s and %3$s correlated perfectly. ",
-                             footnote, variables[pos[i, 1]], variables[pos[i, 2]])
-      }
+    for (i in seq_len(nrow(pos))) {
+      footnote <- gettextf("%1$sVariables %2$s and %3$s correlated perfectly. ",
+                           footnote, variables[pos[i, 1]], variables[pos[i, 2]])
     }
 
     return(footnote)

--- a/R/unidimensionalReliabilityFrequentist.R
+++ b/R/unidimensionalReliabilityFrequentist.R
@@ -1194,7 +1194,7 @@ gettextf <- function(fmt, ..., domain = NULL)  {
     cr[lower.tri(cr, diag = TRUE)] <- 0
     pos <- which(round(cr, 3) == 1, arr.ind = TRUE)
     if (length(pos) == 0) {
-      footnote <- gettextf("%s", footnote)
+      footnote <- footnote
     } else {
       for (i in seq_len(nrow(pos))) {
         footnote <- gettextf("%1$s Variables %2$s and %3$s correlated perfectly. ",

--- a/po/R-de.po
+++ b/po/R-de.po
@@ -289,8 +289,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s Die Variablen %2$s und %3$s sind perfekt korreliert."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$sDie Variablen %2$s und %3$s sind perfekt korreliert."
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "Bitte gib mindestens 2 Variablen ein, um eine Analyse durchzuführen"

--- a/po/R-es.po
+++ b/po/R-es.po
@@ -287,8 +287,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s las variables %2$s y %3$s se correlacionan perfectamente."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$slas variables %2$s y %3$s se correlacionan perfectamente."
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "Por favor, introduzca al menos 2 variables para hacer un análisis"

--- a/po/R-gl.po
+++ b/po/R-gl.po
@@ -294,8 +294,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s As variables %2$s e %3$s están perfectamente correlacionadas."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$sAs variables %2$s e %3$s están perfectamente correlacionadas."
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "Por favor, para facer unha análise introduce 2 variables, cando menos"

--- a/po/R-ja.po
+++ b/po/R-ja.po
@@ -280,8 +280,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s 変数 %2$s と %3$s は完全に相関しています。"
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$s変数 %2$s と %3$s は完全に相関しています。"
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "分析を行うためには、少なくとも2つの変数を入力してください"

--- a/po/R-jaspReliability.pot
+++ b/po/R-jaspReliability.pot
@@ -226,7 +226,7 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
 msgstr ""
 
 msgid "Please enter at least 2 variables to do an analysis"

--- a/po/R-nl.po
+++ b/po/R-nl.po
@@ -286,8 +286,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s Variabelen %2$s en %3$s correleren perfect."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$sVariabelen %2$s en %3$s correleren perfect."
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "Geef a.u.b. minstens 2 variabelen op om een analyse te doen"

--- a/po/R-pt.po
+++ b/po/R-pt.po
@@ -291,8 +291,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s As variáveis %2$s e %3$s se correlacionam perfeitamente."
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$sAs variáveis %2$s e %3$s se correlacionam perfeitamente."
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "Por favor, introduza ao menos 2 variáveis para realizar uma análise"

--- a/po/R-zh_Hant.po
+++ b/po/R-zh_Hant.po
@@ -271,8 +271,8 @@ msgstr ""
 msgid "%s"
 msgstr "%s"
 
-msgid "%1$s Variables %2$s and %3$s correlated perfectly."
-msgstr "%1$s 變項 %2$s 與變項 %3$s 為完全相關"
+msgid "%1$sVariables %2$s and %3$s correlated perfectly."
+msgstr "%1$s變項 %2$s 與變項 %3$s 為完全相關"
 
 msgid "Please enter at least 2 variables to do an analysis"
 msgstr "請輸入至少兩個變項"


### PR DESCRIPTION
Made a minor change to dorp unnecessary translation of a single placeholder.

Only original strings in gettext are valid for translation.