### PR TITLE
Updating allowed variable types

### DIFF
--- a/inst/qml/BlandAltman.qml
+++ b/inst/qml/BlandAltman.qml
@@ -34,7 +34,7 @@ Form
 			id:					pairs
 			name:				"pairs"
 			title:				qsTr("Measurement Pairs")
-			suggestedColumns: 	["scale", "ordinal"]
+			allowedColumns: 	"scale"
 		}
 	}
 

--- a/inst/qml/IntraclassCorrelation.qml
+++ b/inst/qml/IntraclassCorrelation.qml
@@ -33,7 +33,7 @@ Form
 		{
 			name: 			"variables"
 			title: 			qsTr("Variables")
-			allowedColumns: ["scale", "ordinal"]
+			allowedColumns: "scale"
 		}
 	}
 

--- a/inst/qml/UnidimensionalReliabilityBayesian.qml
+++ b/inst/qml/UnidimensionalReliabilityBayesian.qml
@@ -31,7 +31,7 @@ Form
 		{
 			name:			"variables"
 			title:			qsTr("Variables")
-			allowedColumns:	["scale", "ordinal"]
+			allowedColumns:	"scale"
 			id:				vars
 		}
 	}

--- a/inst/qml/UnidimensionalReliabilityFrequentist.qml
+++ b/inst/qml/UnidimensionalReliabilityFrequentist.qml
@@ -33,7 +33,7 @@ Form
 		{
 			name: 			"variables"
 			title: 			qsTr("Variables")
-			allowedColumns: ["scale", "ordinal"]
+			allowedColumns: "scale"
 		}
 	}
 


### PR DESCRIPTION
Removing 'ordinal' as an allowed data type because all analyses that specified a data type automatically cast the data to numeric.