### PR TITLE
fix analytic SEs for alpha and lambda2 with continuous data

### DIFF
--- a/R/unidimensionalReliabilityFrequentist.R
+++ b/R/unidimensionalReliabilityFrequentist.R
@@ -1,8 +1,7 @@
 
-
-
 #' @export
 unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) {
+
 
   # check for listwise deletion
   datasetOld <- dataset
@@ -43,7 +42,6 @@ unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) 
   .frequentistItemTable(jaspResults, model, options)
   .frequentistSingleFactorFitTable(jaspResults, model, options)
   .frequentistLoadingsTable(jaspResults, model, options)
-
 
   return()
 
@@ -1898,27 +1896,6 @@ unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) 
   return(.seVar(x)/ (2 * sd(x, na.rm = TRUE)))
 }
 
-
-# SE of sample lambda-2
-.seLambda2 <- function(X, VC = NULL, eps = 1e-16) {
-  J <- ncol(X)
-  if(is.null(VC))
-    VC <- .varCM(X)
-  C <- var(X)
-  C. <- C; diag(C.) <- 0
-  vecC. <- matrix(C., nrow = 1)
-  C2plus <- sum(C.^2)
-  Cplus <- sum(C.)
-  Splus <- sum(C)
-  C2plusX <- sqrt(J / (J-1) * C2plus)
-
-  e <-  matrix(diag(rep(1, J)), nrow = 1)
-  u <-  matrix(1, nrow = 1, ncol = J^2)
-  G <- (((C2plusX / C2plus * vecC. + (u - e)) - .lambda2(X)) / Splus)
-  return(sqrt(G %*% VC %*% t(G)))
-}
-
-
 # SE of sample lambda-3 (alpha)
 .seLambda3 <- function(X, VC = NULL, eps = 1e-16){
   J <- ncol(X)
@@ -1930,7 +1907,18 @@ unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) 
 .seLambda1 <- function(X, VC = NULL, eps = 1e-16){
   D <- function(x) diag(as.numeric(x))
   J <- ncol(X)
-  if(is.null(VC)) VC <- .varCM(X)
+  # if(is.null(VC)) VC <- .varCM(X)
+  if (is.null(VC)) {
+    levs <- sapply(as.data.frame(X), function(col) length(unique(col[!is.na(col)])))
+    if (any(levs > 12)) {
+      # Continuous/mixed: fast, stable normal-theory VC
+      VC <- .varVCwishart(stats::var(X), nrow(X))
+    } else {
+      # Ordinal: keep your existing categorical VC
+      VC <- .varCM(X)
+    }
+  }
+
   g0 <- vecC <- matrix(var(X))
   e <-  matrix(diag(rep(1, J)), nrow = 1)
   u <-  matrix(1, nrow = 1, ncol = J^2)
@@ -2014,12 +2002,42 @@ unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) 
   return(VC)
 }
 
+# SE of sample lambda-2
+.seLambda2 <- function(X, VC = NULL, eps = 1e-16) {
+  J <- ncol(X)
+  # if(is.null(VC)) VC <- .varCM(X)
+  if (is.null(VC)) {
+    levs <- sapply(as.data.frame(X), function(col) length(unique(col[!is.na(col)])))
+    if (any(levs > 12)) {
+      # Continuous/mixed: fast, stable normal-theory VC
+      VC <- .varVCwishart(stats::var(X), nrow(X))
+    } else {
+      # Ordinal: keep your existing categorical VC
+      VC <- .varCM(X)
+    }
+  }
+
+  C <- var(X)
+  C. <- C; diag(C.) <- 0
+  vecC. <- matrix(C., nrow = 1)
+  C2plus <- sum(C.^2)
+  Cplus <- sum(C.)
+  Splus <- sum(C)
+  C2plusX <- sqrt(J / (J-1) * C2plus)
+
+  e <-  matrix(diag(rep(1, J)), nrow = 1)
+  u <-  matrix(1, nrow = 1, ncol = J^2)
+  G <- (((C2plusX / C2plus * vecC. + (u - e)) - .lambda2(X)) / Splus)
+  return(sqrt(G %*% VC %*% t(G)))
+}
+
 # Sample lambda-2
 .lambda2 <- function(X){
   J <- ncol(X)
   C <- var(X)
   return(((sum(C)-sum(diag(C))) + (sqrt((J/(J-1))*(sum(C^2)-sum(diag(C^2))))))/sum(C))
 }
+
 
 
 .splithalfData <- function(X, splits, useCase) {
@@ -2071,3 +2089,195 @@ unidimensionalReliabilityFrequentist <- function(jaspResults, dataset, options) 
   up <- (exp(2 * zup) - 1) / (exp(2 * zup) + 1)
   return(c(low, up))
 }
+
+.varVCwishart <- function(Sigma, n) {
+  # Var(vec(S)) for sample covariance with denominator (n-1), under MVN
+  J  <- ncol(Sigma); nu <- n - 1L
+  VC <- matrix(0, J*J, J*J)
+  idx <- function(a,b) (a-1L)*J + b
+  for (i in 1:J) for (j in 1:J) for (k in 1:J) for (l in 1:J) {
+    VC[idx(i,j), idx(k,l)] <- (Sigma[i,k]*Sigma[j,l] + Sigma[i,l]*Sigma[j,k]) / nu
+  }
+  VC
+}
+
+
+# ##### Functions from ChatGPT #####
+# # ---------- helpers ----------
+# .diagVec <- function(x) diag(as.numeric(x))
+#
+# .isContinuousVec <- function(x, maxLevels = 10, minPropUnique = 0.25, tol = 1e-8) {
+#   x <- x[!is.na(x)]
+#   if (!length(x)) return(FALSE)
+#   u <- length(unique(x))
+#   propU <- u / length(x)
+#   integerish <- all(abs(x - round(x)) < tol)
+#   (u > maxLevels && propU >= minPropUnique) || !integerish
+# }
+#
+# .detectContinuous <- function(X, maxLevels = 10, minPropUnique = 0.25, tol = 1e-8) {
+#   as.logical(vapply(X, .isContinuousVec, logical(1),
+#                     maxLevels = maxLevels,
+#                     minPropUnique = minPropUnique,
+#                     tol = tol))
+# }
+#
+# .varVcEmpirical <- function(X) {
+#   X <- as.matrix(X)
+#   X <- sweep(X, 2, colMeans(X, na.rm = TRUE), "-")
+#   n <- nrow(X); J <- ncol(X)
+#   M <- matrix(NA_real_, n, J * J)
+#   for (t in seq_len(n)) {
+#     zzT <- tcrossprod(X[t, , drop = FALSE])
+#     M[t, ] <- as.vector(zzT)
+#   }
+#   stats::cov(M) * n / (n - 1)^2
+# }
+#
+# .getVc <- function(X, maxLevels = 10, minPropUnique = 0.25, tol = 1e-8) {
+#   isCont <- .detectContinuous(X, maxLevels, minPropUnique, tol)
+#   if (all(!isCont)) .varCM(X) else .varVcEmpirical(X)
+# }
+#
+# # ---------- main SE functions ----------
+# .seLambda1 <- function(X, VC = NULL, eps = 1e-16) {
+#   J <- ncol(X)
+#   if (is.null(VC)) VC <- .getVc(X)
+#
+#   g0 <- matrix(stats::var(X))
+#   e  <- matrix(diag(rep(1, J)), nrow = 1)
+#   u  <- matrix(1, nrow = 1, ncol = J^2)
+#
+#   A1 <- rbind(e, u, u)
+#   A2 <- matrix(c(1, 0, -1,   # log(sumDiag) - log(sumAll)  -> exp = sumDiag/sumAll
+#                  0, 0,  0),  # 0                           -> exp = 1
+#                2, 3, byrow = TRUE)
+#
+#   A3 <- matrix(c(-1, 1), nrow = 1, ncol = 2)
+#
+#   g1 <- log(A1 %*% g0 + eps)
+#   g2 <- exp(A2 %*% g1)
+#
+#   G1 <- .diagVec(1 / (A1 %*% g0)) %*% A1
+#   G2 <- .diagVec(g2) %*% A2 %*% G1
+#   G  <- A3 %*% G2
+#
+#   V <- G %*% VC %*% t(G)
+#   sqrt(V)
+# }
+#
+# .seLambda3 <- function(X, VC = NULL, eps = 1e-16) {
+#   J <- ncol(X)
+#   (J / (J - 1)) * .seLambda1(X, VC, eps)
+# }
+#
+# .varCM <- function(X, marg = marg.default, eps = 1e-16) {
+#
+#   X2nR <- function(X){
+#     if (!is.matrix(X)) X <- as.matrix(X)
+#     n <- as.matrix(table(apply(X, 1, paste, collapse=",")))                               # MODIFIED on 30-aug-2024
+#     R <- matrix(as.numeric(unlist(strsplit(dimnames(n)[[1]], ","))), ncol = ncol(X), byrow = TRUE)
+#     return(list(n = n, R = R))
+#   }
+#   D <- function(x) diag(as.numeric(x))
+#   Rij <- function(i, j, x) {
+#     if (i == j) {
+#       tmp <- expand.grid(x[[i]]);
+#       tmp <- unlist(tmp)
+#       tmp <- matrix(rep(rep(tmp, each = length(tmp)), 2), ncol = 2)
+#       return(tmp)
+#     } else {
+#       tmp <- expand.grid(x[[i]], x[[j]]);
+#       return(tmp[, ncol(tmp):1])
+#     }
+#   }
+#
+#   X <- X - min(X, na.rm = TRUE) + 1
+#   res <- X2nR(X)
+#   R <- res$R
+#   n <- res$n
+#   J <- ncol(R)
+#   K <- length(n)
+#   marg.default <- list()
+#   for (j in 1 : J) marg.default[[j]] <- sort(unique(R[, j]))
+#   marg <- marg.default # remove line when not testing
+#   eps <- 1e-16         # remove line when not testing
+#
+#   A2 <- matrix(c(1, 0, 0, 0,  1, 0, 0, 0,  0, 1, 0, 0,  -1, 0, 1, 1,  0, 0, 0, -1), 4, 5)
+#   A3 <- matrix(c(-1, 0,  1, 0,  0, 1,  0, -1), 2, 4)
+#   A4 <- matrix(c(1, -1), 1, 2)
+#   # nrowG <- .5 * J * (J+1)
+#   nrowG <- J^2
+#   G <- matrix(NA, nrowG, K)
+#   labG <- rep(NA, nrowG)
+#   iter <- i <- j <- 0
+#   for (i in (1:(J))) for (j in ((1):J)){  # all variances and covariances (once)
+#     iter <- iter + 1
+#     if (i <= j) {
+#       M2 <- NULL
+#       A1 <- NULL
+#       for (a in marg[[i]]) for (b in marg[[j]]) M2 <- rbind(M2,as.numeric(R[,i]==a & R[,j]==b))
+#       tmp <- Rij(i, j, marg)
+#       A1 <- t(cbind(tmp[, 1], tmp[, 2], tmp[, 1] * tmp[, 2], 1, 1))
+#       g1 <- log(A1 %*% M2 %*% n + eps)
+#       g2 <- exp(A2 %*% g1)
+#       A3g2 <- matrix(A3 %*% g2, nrow = 2)
+#       g4 <- matrix(A3g2[1, ] / A3g2[2, ])
+#       G[(i - 1) * J + j, ]  <- g4 %*% A4 %*% D(1/(A3 %*% g2 + eps)) %*% A3 %*% D(g2) %*% A2 %*% D(1/(A1 %*% M2 %*% n + eps)) %*% A1 %*% M2
+#       labG[(i - 1) * J + j] <- paste(i, ",", j, sep = "")
+#       if (i < j) {
+#         G[(j - 1) * J + i, ] <- G[(i - 1) * J + j, ]
+#         labG[(j - 1) * J + i] <- paste(j, ",", i, sep = "")
+#       }
+#     }
+#   }
+#   dimnames(G) <- list(labG, dimnames(n)[[1]])
+#   Vn <- D(n) - n %*% t(n) / sum(n)
+#   VC <- G %*% Vn %*% t(G) - (G %*% n %*% t(n) %*% t(G))/sum(n)
+#   return(VC)
+# }
+#
+#
+#
+# # ----- value -----
+# .lambda2 <- function(X) {
+#   S <- stats::var(X); J <- ncol(S)
+#   off <- S; diag(off) <- 0
+#   A <- sum(off)                              # sum of off-diagonals
+#   B <- sum(off^2)                            # sum of off-diagonal squares
+#   k <- J / (J - 1)
+#   (A + sqrt(k * B)) / sum(S)
+# }
+#
+# # ----- SE via delta method (exact gradient) -----
+# .seLambda2 <- function(X, VC = NULL, useOrdinalVc = TRUE, eps = 1e-12) {
+#   S <- stats::var(X); J <- ncol(S)
+#   if (is.null(VC)) VC <- if (useOrdinalVc) .varCM(X) else .varVcEmpirical(X)
+#
+#   Tsum <- sum(S)
+#   off  <- S; diag(off) <- 0
+#   A <- sum(off)
+#   B <- sum(off^2)
+#   k <- J / (J - 1)
+#   R <- sqrt(max(k * B, 0))                   # = sqrt(kB); guard tiny/zero
+#
+#   s <- as.vector(S)
+#   d <- as.vector(diag(J))                    # diagonal selector
+#   u <- rep(1, J * J)                         # all-ones selector
+#   o <- 1 - d                                 # off-diagonal selector
+#
+#   # ∂N/∂vec(S) with N = A + sqrt(kB)
+#   # = o + (k / sqrt(kB)) * (o * s); set second term to 0 if R==0
+#   q <- o + if (R > 0) (k / R) * (o * s) else 0 * s
+#
+#   N <- A + R
+#   G <- matrix((q * Tsum - N * u) / (Tsum^2), nrow = 1)   # dλ2/dvec(S)
+#
+#   V <- as.numeric(G %*% VC %*% t(G))
+#   if (!is.finite(V) || V < -eps) {
+#     warning("Delta variance for lambda2 not positive; returning NA")
+#     return(matrix(NA_real_, 1, 1))
+#   }
+#   V <- max(V, 0)
+#   matrix(sqrt(V), 1, 1)
+# }

--- a/renv.lock
+++ b/renv.lock
@@ -336,10 +336,10 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.14",
+      "Version": "1.1.0",
       "Source": "Repository",
       "Title": "Seamless R and C++ Integration",
-      "Date": "2025-01-11",
+      "Date": "2025-07-01",
       "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(\"Romain\", \"Francois\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"JJ\", \"Allaire\", role = \"aut\", comment = c(ORCID = \"0000-0003-0174-9868\")), person(\"Kevin\", \"Ushey\", role = \"aut\", comment = c(ORCID = \"0000-0003-2880-7407\")), person(\"Qiang\", \"Kou\", role = \"aut\", comment = c(ORCID = \"0000-0001-6786-5453\")), person(\"Nathan\", \"Russell\", role = \"aut\"), person(\"Iñaki\", \"Ucar\", role = \"aut\", comment = c(ORCID = \"0000-0001-6403-5550\")), person(\"Doug\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"John\", \"Chambers\", role = \"aut\"))",
       "Description": "The 'Rcpp' package provides R functions as well as C++ classes which offer a seamless integration of R and C++. Many R data types and objects can be mapped back and forth to C++ equivalents which facilitates both writing of new code as well as easier integration of third-party libraries. Documentation about 'Rcpp' is provided by several vignettes included in this package, via the 'Rcpp Gallery' site at <https://gallery.rcpp.org>, the paper by Eddelbuettel and Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013, <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018, <doi:10.1080/00031305.2017.1375990>); see 'citation(\"Rcpp\")' for details.",
       "Imports": [
@@ -359,17 +359,17 @@
       "RoxygenNote": "6.1.1",
       "Encoding": "UTF-8",
       "NeedsCompilation": "yes",
-      "Author": "Dirk Eddelbuettel [aut, cre] (<https://orcid.org/0000-0001-6419-907X>), Romain Francois [aut] (<https://orcid.org/0000-0002-2444-4226>), JJ Allaire [aut] (<https://orcid.org/0000-0003-0174-9868>), Kevin Ushey [aut] (<https://orcid.org/0000-0003-2880-7407>), Qiang Kou [aut] (<https://orcid.org/0000-0001-6786-5453>), Nathan Russell [aut], Iñaki Ucar [aut] (<https://orcid.org/0000-0001-6403-5550>), Doug Bates [aut] (<https://orcid.org/0000-0001-8316-9503>), John Chambers [aut]",
+      "Author": "Dirk Eddelbuettel [aut, cre] (ORCID: <https://orcid.org/0000-0001-6419-907X>), Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>), JJ Allaire [aut] (ORCID: <https://orcid.org/0000-0003-0174-9868>), Kevin Ushey [aut] (ORCID: <https://orcid.org/0000-0003-2880-7407>), Qiang Kou [aut] (ORCID: <https://orcid.org/0000-0001-6786-5453>), Nathan Russell [aut], Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>), Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>), John Chambers [aut]",
       "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
       "Repository": "CRAN"
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "14.4.3-1",
+      "Version": "14.6.3-1",
       "Source": "Repository",
       "Type": "Package",
       "Title": "'Rcpp' Integration for the 'Armadillo' Templated Linear Algebra Library",
-      "Date": "2025-05-21",
+      "Date": "2025-08-14",
       "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\", comment = c(ORCID = \"0000-0001-6419-907X\")), person(\"Romain\", \"Francois\", role = \"aut\", comment = c(ORCID = \"0000-0002-2444-4226\")), person(\"Doug\", \"Bates\", role = \"aut\", comment = c(ORCID = \"0000-0001-8316-9503\")), person(\"Binxiang\", \"Ni\", role = \"aut\"), person(\"Conrad\", \"Sanderson\", role = \"aut\", comment = c(ORCID = \"0000-0002-0049-4501\")))",
       "Description": "'Armadillo' is a templated C++ linear algebra library (by Conrad Sanderson) that aims towards a good balance between speed and ease of use. Integer, floating point and complex numbers are supported, as well as a subset of trigonometric and statistics functions. Various matrix decompositions are provided through optional integration with LAPACK and ATLAS libraries.  The 'RcppArmadillo' package includes the header files from the templated 'Armadillo' library. Thus users do not need to install 'Armadillo' itself in order to use 'RcppArmadillo'. From release 7.800.0 on, 'Armadillo' is licensed under Apache License 2; previous releases were under licensed as MPL 2.0 from version 3.800.0 onwards and LGPL-3 prior to that; 'RcppArmadillo' (the 'Rcpp' bindings/bridge to Armadillo) is licensed under the GNU GPL version 2 or later, as is the rest of 'Rcpp'.",
       "License": "GPL (>= 2)",
@@ -399,8 +399,7 @@
       "NeedsCompilation": "yes",
       "Author": "Dirk Eddelbuettel [aut, cre] (ORCID: <https://orcid.org/0000-0001-6419-907X>), Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>), Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>), Binxiang Ni [aut], Conrad Sanderson [aut] (ORCID: <https://orcid.org/0000-0002-0049-4501>)",
       "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
-      "Repository": "https://packagemanager.posit.co/cran/latest",
-      "Encoding": "UTF-8"
+      "Repository": "CRAN"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
@@ -475,7 +474,7 @@
     },
     "SimDesign": {
       "Package": "SimDesign",
-      "Version": "2.19.2",
+      "Version": "2.20.0",
       "Source": "Repository",
       "Title": "Structure for Organizing Monte Carlo Simulation Designs",
       "Authors@R": "c(person(\"Phil\", \"Chalmers\", email = \"rphilip.chalmers@gmail.com\", role = c(\"aut\", \"cre\"), comment = c(ORCID=\"0000-0001-5332-2810\")), person(\"Matthew\", \"Sigal\", role = c(\"ctb\")), person(\"Ogreden\", family=\"Oguzhan\", role = c(\"ctb\")), person(\"Mikko \", family=\"Ronkko\", role = c(\"ctb\")), person(\"Moritz\", family=\"Ketzer\", role = c(\"ctb\")))",
@@ -500,6 +499,7 @@
         "stats"
       ],
       "Suggests": [
+        "snow",
         "knitr",
         "ggplot2",
         "tidyr",
@@ -523,7 +523,7 @@
       "RoxygenNote": "7.3.2",
       "Encoding": "UTF-8",
       "NeedsCompilation": "no",
-      "Author": "Phil Chalmers [aut, cre] (<https://orcid.org/0000-0001-5332-2810>), Matthew Sigal [ctb], Ogreden Oguzhan [ctb], Mikko Ronkko [ctb], Moritz Ketzer [ctb]",
+      "Author": "Phil Chalmers [aut, cre] (ORCID: <https://orcid.org/0000-0001-5332-2810>), Matthew Sigal [ctb], Ogreden Oguzhan [ctb], Mikko Ronkko [ctb], Moritz Ketzer [ctb]",
       "Maintainer": "Phil Chalmers <rphilip.chalmers@gmail.com>",
       "Repository": "CRAN"
     },
@@ -945,7 +945,7 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "6.4.0",
+      "Version": "7.0.0",
       "Source": "Repository",
       "Type": "Package",
       "Title": "A Modern and Flexible Web Client for R",
@@ -969,7 +969,7 @@
       "Depends": [
         "R (>= 3.0.0)"
       ],
-      "RoxygenNote": "7.3.2.9000",
+      "RoxygenNote": "7.3.2",
       "Encoding": "UTF-8",
       "Language": "en-US",
       "NeedsCompilation": "yes",
@@ -979,7 +979,7 @@
     },
     "data.table": {
       "Package": "data.table",
-      "Version": "1.17.6",
+      "Version": "1.17.8",
       "Source": "Repository",
       "Title": "Extension of `data.frame`",
       "Depends": [
@@ -1392,7 +1392,7 @@
     },
     "future": {
       "Package": "future",
-      "Version": "1.58.0",
+      "Version": "1.67.0",
       "Source": "Repository",
       "Title": "Unified Parallel and Distributed Processing in R for Everyone",
       "Depends": [
@@ -1423,6 +1423,7 @@
       "Language": "en-US",
       "Encoding": "UTF-8",
       "RoxygenNote": "7.3.2",
+      "Collate": "'000.bquote.R' '000.import.R' '000.re-exports.R' '010.tweakable.R' '010.utils-parallelly.R' 'backend_api-01-FutureBackend-class.R' 'backend_api-03.MultiprocessFutureBackend-class.R' 'backend_api-11.ClusterFutureBackend-class.R' 'backend_api-11.MulticoreFutureBackend-class.R' 'backend_api-11.SequentialFutureBackend-class.R' 'backend_api-13.MultisessionFutureBackend-class.R' 'backend_api-ConstantFuture-class.R' 'backend_api-Future-class.R' 'backend_api-FutureRegistry.R' 'backend_api-UniprocessFuture-class.R' 'backend_api-evalFuture.R' 'core_api-cancel.R' 'core_api-future.R' 'core_api-reset.R' 'core_api-resolved.R' 'core_api-value.R' 'delayed_api-futureAssign.R' 'delayed_api-futureOf.R' 'demo_api-mandelbrot.R' 'infix_api-01-futureAssign_OP.R' 'infix_api-02-globals_OP.R' 'infix_api-03-seed_OP.R' 'infix_api-04-stdout_OP.R' 'infix_api-05-conditions_OP.R' 'infix_api-06-lazy_OP.R' 'infix_api-07-label_OP.R' 'infix_api-08-plan_OP.R' 'infix_api-09-tweak_OP.R' 'protected_api-FutureCondition-class.R' 'protected_api-FutureGlobals-class.R' 'protected_api-FutureResult-class.R' 'protected_api-futures.R' 'protected_api-globals.R' 'protected_api-journal.R' 'protected_api-resolve.R' 'protected_api-signalConditions.R' 'testme.R' 'utils-basic.R' 'utils-conditions.R' 'utils-connections.R' 'utils-debug.R' 'utils-immediateCondition.R' 'utils-marshalling.R' 'utils-objectSize.R' 'utils-options.R' 'utils-prune_pkg_code.R' 'utils-registerClusterTypes.R' 'utils-rng_utils.R' 'utils-signalEarly.R' 'utils-stealth_sample.R' 'utils-sticky_globals.R' 'utils-tweakExpression.R' 'utils-uuid.R' 'utils-whichIndex.R' 'utils_api-backtrace.R' 'utils_api-capture_journals.R' 'utils_api-futureCall.R' 'utils_api-futureSessionInfo.R' 'utils_api-makeClusterFuture.R' 'utils_api-minifuture.R' 'utils_api-nbrOfWorkers.R' 'utils_api-plan.R' 'utils_api-plan-with.R' 'utils_api-sessionDetails.R' 'utils_api-tweak.R' 'zzz.R'",
       "NeedsCompilation": "no",
       "Author": "Henrik Bengtsson [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-7579-5165>)",
       "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
@@ -1947,40 +1948,74 @@
       "Package": "jaspBase",
       "Version": "0.20.0",
       "Source": "GitHub",
-      "Requirements": [
+      "Type": "Package",
+      "Title": "JASP Base",
+      "Author": "JASP Team",
+      "Maintainer": "Bruno Boutin <B.Boutin@uva.nl>",
+      "Description": "Package contains the JASP Bayesian and Frequentist analyses. See <https://jasp-stats.org> for more details.",
+      "License": "GPL2+",
+      "Imports": [
         "cli",
         "codetools",
+        "compiler",
         "ggplot2",
+        "grDevices",
+        "grid",
         "gridExtra",
         "gridGraphics",
         "jaspGraphs",
         "jsonlite",
         "lifecycle",
+        "methods",
         "officer",
         "pkgbuild",
         "plyr",
         "ragg",
         "R6",
-        "Rcpp",
+        "Rcpp (>= 0.12.14)",
         "rvg",
         "svglite",
         "systemfonts",
-        "withr",
-        "testthat"
+        "withr"
       ],
+      "RoxygenNote": "7.3.2",
+      "Roxygen": "list(markdown = TRUE)",
+      "Encoding": "UTF-8",
+      "LinkingTo": [
+        "Rcpp"
+      ],
+      "RcppModules": "jaspResults",
+      "NeedsCompilation": "yes",
+      "Suggests": [
+        "testthat (>= 3.0.0)"
+      ],
+      "Config/testthat/edition": "3",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
       "RemoteRepo": "jaspBase",
-      "RemoteSha": "9dd637722c25bf0ea035ccaabf58ef9faf36b852"
+      "RemoteRef": "master",
+      "RemoteSha": "0f0f59e18f5524ea422cb3dc5ad76ace6f0518e4",
+      "Remotes": "jasp-stats/jaspGraphs"
     },
     "jaspGraphs": {
       "Package": "jaspGraphs",
       "Version": "0.20.0",
       "Source": "GitHub",
-      "Requirements": [
-        "testthat",
-        "ggplot2",
+      "Type": "Package",
+      "Title": "Custom Graphs for JASP",
+      "Author": "Don van den Bergh",
+      "Maintainer": "JASP-team <info@jasp-stats.nl>",
+      "Description": "Graph making functions and wrappers for JASP.",
+      "License": "GPL",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "RoxygenNote": "7.3.2",
+      "Suggests": [
+        "testthat"
+      ],
+      "Imports": [
+        "ggplot2 (>= 3.0.0)",
         "gridExtra",
         "gtable",
         "lifecycle",
@@ -1991,11 +2026,49 @@
         "scales",
         "viridisLite"
       ],
+      "Roxygen": "list(markdown = TRUE)",
+      "RemoteType": "github",
+      "RemoteUsername": "jasp-stats",
+      "RemoteRepo": "jaspGraphs",
+      "RemoteRef": "master",
+      "RemoteSha": "c2c853c6d866096f143f191bf238e392e0dfaad2",
+      "RemoteHost": "api.github.com"
+    },
+    "jaspTools": {
+      "Package": "jaspTools",
+      "Version": "0.20.0",
+      "Source": "GitHub",
+      "Type": "Package",
+      "Title": "Helps Preview and Debug JASP Analyses",
+      "Authors@R": "c( person(\"Tim\", \"de Jong\", role = \"aut\"), person(\"Don\", \"van den Bergh\", role = c(\"ctb\", \"cre\"), email = \"d.vandenbergh@uva.nl\"))",
+      "Maintainer": "Don van den Bergh <d.vandenbergh@uva.nl>",
+      "Description": "This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.",
+      "License": "GNU General Public License",
+      "Encoding": "UTF-8",
+      "LazyData": "true",
+      "Imports": [
+        "archive (>= 1.1.6)",
+        "data.table",
+        "httr",
+        "jsonlite",
+        "lifecycle",
+        "pkgload",
+        "remotes",
+        "rjson",
+        "stringi",
+        "stringr",
+        "testthat (>= 3.0.3)",
+        "vdiffr (>= 1.0.7)"
+      ],
+      "RoxygenNote": "7.3.2",
+      "Roxygen": "list(markdown = TRUE)",
+      "Author": "Tim de Jong [aut], Don van den Bergh [ctb, cre]",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "jasp-stats",
-      "RemoteRepo": "jaspGraphs",
-      "RemoteSha": "c884a4239590cdb08c1f18cbeaad9107395425aa"
+      "RemoteRepo": "jaspTools",
+      "RemoteRef": "master",
+      "RemoteSha": "8a5cf998d43d08f0925ae7bb6083242e0bc6e0ce"
     },
     "jsonlite": {
       "Package": "jsonlite",
@@ -2609,7 +2682,7 @@
     },
     "parallelly": {
       "Package": "parallelly",
-      "Version": "1.45.0",
+      "Version": "1.45.1",
       "Source": "Repository",
       "Title": "Enhancing the 'parallel' Package",
       "Imports": [
@@ -2635,18 +2708,18 @@
       "NeedsCompilation": "yes",
       "Author": "Henrik Bengtsson [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-7579-5165>), Mike Cheng [ctb]",
       "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
-      "Repository": "https://packagemanager.posit.co/cran/latest"
+      "Repository": "CRAN"
     },
     "pbapply": {
       "Package": "pbapply",
-      "Version": "1.7-2",
+      "Version": "1.7-4",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Adding Progress Bar to '*apply' Functions",
-      "Date": "2023-06-27",
+      "Date": "2025-07-19",
       "Authors@R": "c(person(given = \"Peter\", family = \"Solymos\", comment = c(ORCID = \"0000-0001-7337-1740\"), role = c(\"aut\", \"cre\"), email = \"psolymos@gmail.com\"), person(given = \"Zygmunt\", family = \"Zawadzki\", role = \"aut\", email = \"zygmunt@zstat.pl\"), person(given = \"Henrik\",  family = \"Bengtsson\",  role = \"ctb\", email = \"henrikb@braju.com\"), person(\"R Core Team\", role = c(\"cph\", \"ctb\")))",
       "Maintainer": "Peter Solymos <psolymos@gmail.com>",
-      "Description": "A lightweight package that adds progress bar to vectorized R functions ('*apply'). The implementation can easily be added to functions where showing the progress is useful (e.g. bootstrap). The type and style of the progress bar (with percentages or remaining time) can be set through options. Supports several parallel processing backends including future.",
+      "Description": "A lightweight package that adds progress bar to vectorized R functions ('*apply'). The implementation can easily be added to functions where showing the progress is useful (e.g. bootstrap). The type and style of the progress bar (with percentages or remaining time) can be set through options. Supports several parallel processing backends including mirai and future.",
       "Depends": [
         "R (>= 3.2.0)"
       ],
@@ -2659,10 +2732,10 @@
         "future.apply"
       ],
       "License": "GPL (>= 2)",
-      "URL": "https://github.com/psolymos/pbapply",
+      "URL": "https://github.com/psolymos/pbapply, https://peter.solymos.org/pbapply/",
       "BugReports": "https://github.com/psolymos/pbapply/issues",
       "NeedsCompilation": "no",
-      "Author": "Peter Solymos [aut, cre] (<https://orcid.org/0000-0001-7337-1740>), Zygmunt Zawadzki [aut], Henrik Bengtsson [ctb], R Core Team [cph, ctb]",
+      "Author": "Peter Solymos [aut, cre] (ORCID: <https://orcid.org/0000-0001-7337-1740>), Zygmunt Zawadzki [aut], Henrik Bengtsson [ctb], R Core Team [cph, ctb]",
       "Repository": "CRAN"
     },
     "pbivnorm": {
@@ -2681,13 +2754,13 @@
     },
     "permute": {
       "Package": "permute",
-      "Version": "0.9-7",
+      "Version": "0.9-8",
       "Source": "Repository",
       "Title": "Functions for Generating Restricted Permutations of Data",
-      "Date": "2022-01-27",
+      "Date": "2025-06-25",
       "Authors@R": "c(person(given = \"Gavin L.\", family = \"Simpson\", email = \"ucfagls@gmail.com\", role = c(\"aut\", \"cph\", \"cre\"), comment = c(ORCID = \"0000-0002-9084-8413\")), person(given = \"R Core Team\", role = \"cph\"), person(given = \"Douglas M.\", family = \"Bates\", role = \"ctb\"), person(given = \"Jari\", family = \"Oksanen\", role = \"ctb\"))",
       "Depends": [
-        "R (>= 2.14.0)"
+        "R (>= 3.6.0)"
       ],
       "Imports": [
         "stats"
@@ -2709,13 +2782,13 @@
       "Copyright": "see file COPYRIGHTS",
       "VignetteBuilder": "knitr",
       "NeedsCompilation": "no",
-      "Author": "Gavin L. Simpson [aut, cph, cre] (<https://orcid.org/0000-0002-9084-8413>), R Core Team [cph], Douglas M. Bates [ctb], Jari Oksanen [ctb]",
+      "Author": "Gavin L. Simpson [aut, cph, cre] (ORCID: <https://orcid.org/0000-0002-9084-8413>), R Core Team [cph], Douglas M. Bates [ctb], Jari Oksanen [ctb]",
       "Maintainer": "Gavin L. Simpson <ucfagls@gmail.com>",
       "Repository": "CRAN"
     },
     "pillar": {
       "Package": "pillar",
-      "Version": "1.10.2",
+      "Version": "1.11.0",
       "Source": "Repository",
       "Title": "Coloured Formatting for Columns",
       "Authors@R": "c(person(given = \"Kirill\", family = \"M\\u00fcller\", role = c(\"aut\", \"cre\"), email = \"kirill@cynkra.com\", comment = c(ORCID = \"0000-0002-1416-3412\")), person(given = \"Hadley\", family = \"Wickham\", role = \"aut\"), person(given = \"RStudio\", role = \"cph\"))",
@@ -2766,7 +2839,7 @@
       "Config/gha/extra-packages": "units=?ignore-before-r=4.3.0",
       "Config/Needs/website": "tidyverse/tidytemplate",
       "NeedsCompilation": "no",
-      "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>), Hadley Wickham [aut], RStudio [cph]",
+      "Author": "Kirill Müller [aut, cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>), Hadley Wickham [aut], RStudio [cph]",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>",
       "Repository": "CRAN"
     },
@@ -3066,9 +3139,9 @@
     },
     "psych": {
       "Package": "psych",
-      "Version": "2.5.3",
+      "Version": "2.5.6",
       "Source": "Repository",
-      "Date": "2025-03-18",
+      "Date": "2025-06-20",
       "Title": "Procedures for Psychological, Psychometric, and Personality Research",
       "Authors@R": "person(\"William\", \"Revelle\", role =c(\"aut\",\"cre\"), email=\"revelle@northwestern.edu\", comment=c(ORCID  = \"0000-0003-4880-9610\") )",
       "Description": "A general purpose toolbox developed originally for personality, psychometric theory and experimental psychology.  Functions are primarily for multivariate analysis and scale construction using factor analysis, principal component analysis, cluster analysis and reliability analysis, although others provide basic descriptive statistics. Item Response Theory is done using  factor analysis of tetrachoric and polychoric correlations. Functions for analyzing data at multiple levels include within and between group statistics, including correlations and factor analysis.  Validation and cross validation of scales developed using basic machine learning algorithms are provided, as are functions for simulating and testing particular item and test structures. Several functions  serve as a useful front end for structural equation modeling.  Graphical displays of path diagrams, including mediation models, factor analysis and structural equation models are created using basic graphics. Some of the functions are written to support a book on psychometric theory as well as publications in personality research. For more information, see the <https://personality-project.org/r/> web page.",
@@ -3098,7 +3171,7 @@
       "VignetteBuilder": "knitr",
       "URL": "https://personality-project.org/r/psych/ https://personality-project.org/r/psych-manual.pdf",
       "NeedsCompilation": "no",
-      "Author": "William Revelle [aut, cre] (<https://orcid.org/0000-0003-4880-9610>)",
+      "Author": "William Revelle [aut, cre] (ORCID: <https://orcid.org/0000-0003-4880-9610>)",
       "Maintainer": "William Revelle <revelle@northwestern.edu>",
       "Repository": "CRAN"
     },
@@ -3260,7 +3333,7 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.1.4",
+      "Version": "1.1.5",
       "Source": "Repository",
       "Type": "Package",
       "Title": "Project Environments",
@@ -3279,6 +3352,7 @@
         "covr",
         "cpp11",
         "devtools",
+        "generics",
         "gitcreds",
         "jsonlite",
         "jsonvalidate",
@@ -3307,7 +3381,7 @@
       "Config/testthat/parallel": "true",
       "Config/testthat/start-first": "bioconductor,python,install,restore,snapshot,retrieve,remotes",
       "NeedsCompilation": "no",
-      "Author": "Kevin Ushey [aut, cre] (<https://orcid.org/0000-0003-2880-7407>), Hadley Wickham [aut] (<https://orcid.org/0000-0003-4757-117X>), Posit Software, PBC [cph, fnd]",
+      "Author": "Kevin Ushey [aut, cre] (ORCID: <https://orcid.org/0000-0003-2880-7407>), Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Posit Software, PBC [cph, fnd]",
       "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
       "Repository": "CRAN"
     },
@@ -3381,7 +3455,7 @@
     },
     "rprojroot": {
       "Package": "rprojroot",
-      "Version": "2.0.4",
+      "Version": "2.1.0",
       "Source": "Repository",
       "Title": "Finding Files in Project Subdirectories",
       "Authors@R": "person(given = \"Kirill\", family = \"M\\u00fcller\", role = c(\"aut\", \"cre\"), email = \"kirill@cynkra.com\", comment = c(ORCID = \"0000-0002-1416-3412\"))",
@@ -3396,18 +3470,20 @@
         "covr",
         "knitr",
         "lifecycle",
-        "mockr",
         "rlang",
         "rmarkdown",
-        "testthat (>= 3.0.0)",
+        "testthat (>= 3.2.0)",
         "withr"
       ],
       "VignetteBuilder": "knitr",
       "Config/testthat/edition": "3",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.2.3",
+      "RoxygenNote": "7.3.2.9000",
+      "Config/autostyle/scope": "line_breaks",
+      "Config/autostyle/strict": "true",
+      "Config/Needs/website": "tidyverse/tidytemplate",
       "NeedsCompilation": "no",
-      "Author": "Kirill Müller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>)",
+      "Author": "Kirill Müller [aut, cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>)",
       "Maintainer": "Kirill Müller <kirill@cynkra.com>",
       "Repository": "CRAN"
     },
@@ -4131,7 +4207,7 @@
     },
     "waldo": {
       "Package": "waldo",
-      "Version": "0.6.1",
+      "Version": "0.6.2",
       "Source": "Repository",
       "Title": "Find Differences Between R Objects",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")) )",
@@ -4206,7 +4282,7 @@
     },
     "xml2": {
       "Package": "xml2",
-      "Version": "1.3.8",
+      "Version": "1.4.0",
       "Source": "Repository",
       "Title": "Parse XML",
       "Authors@R": "c( person(\"Hadley\", \"Wickham\", role = \"aut\"), person(\"Jim\", \"Hester\", role = \"aut\"), person(\"Jeroen\", \"Ooms\", email = \"jeroenooms@gmail.com\", role = c(\"aut\", \"cre\")), person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")), person(\"R Foundation\", role = \"ctb\", comment = \"Copy of R-project homepage cached as example\") )",
@@ -4236,7 +4312,7 @@
       "VignetteBuilder": "knitr",
       "Config/Needs/website": "tidyverse/tidytemplate",
       "Encoding": "UTF-8",
-      "RoxygenNote": "7.2.3",
+      "RoxygenNote": "7.3.2",
       "SystemRequirements": "libxml2: libxml2-dev (deb), libxml2-devel (rpm)",
       "Collate": "'S4.R' 'as_list.R' 'xml_parse.R' 'as_xml_document.R' 'classes.R' 'format.R' 'import-standalone-obj-type.R' 'import-standalone-purrr.R' 'import-standalone-types-check.R' 'init.R' 'nodeset_apply.R' 'paths.R' 'utils.R' 'xml2-package.R' 'xml_attr.R' 'xml_children.R' 'xml_document.R' 'xml_find.R' 'xml_missing.R' 'xml_modify.R' 'xml_name.R' 'xml_namespaces.R' 'xml_node.R' 'xml_nodeset.R' 'xml_path.R' 'xml_schema.R' 'xml_serialize.R' 'xml_structure.R' 'xml_text.R' 'xml_type.R' 'xml_url.R' 'xml_write.R' 'zzz.R'",
       "Config/testthat/edition": "3",

--- a/renv/activate.R
+++ b/renv/activate.R
@@ -2,7 +2,7 @@
 local({
 
   # the requested version of renv
-  version <- "1.1.4"
+  version <- "1.1.5"
   attr(version, "sha") <- NULL
 
   # the project directory


### PR DESCRIPTION
This fixes https://github.com/jasp-stats/jasp-issues/issues/3622

This was actually not a loop. A while ago we switched to analytic SEs for the confidence intervals of alpha and lambda2, based on the code by Andries van der Ark. However, only now I noticed that the way the these are computed is tailored to categorical data. With continuous data there are insanely huge matrices created (for category combinations). I now changed the method for continuous data to use the wishart approach for SEs of the covariances of the scores. 

For testing:
[Decathlon.jasp.zip](https://github.com/user-attachments/files/21934910/Decathlon.jasp.zip)
